### PR TITLE
Auto add HTTP:// if missing from URL in dir mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -195,6 +195,10 @@ func ParseCmdLine() *State {
 		if strings.HasSuffix(s.Url, "/") == false {
 			s.Url = s.Url + "/"
 		}
+		
+		if strings.HasPrefix(s.Url, "http") == false {
+			s.Url = "http://" + s.Url
+		}
 
 		// extensions are comma seaprated
 		if extensions != "" {


### PR DESCRIPTION
Because I'm lazy/forget to add, it will now auto add 'http://' when it's not included in the URL (`-u <url>`) when in `dir` mode (`-m dir`).

Defaults to HTTP. Still able to use http**s**.

- - -

### Before 

```
[root:~/gobuster]# go run main.go -u g0tmi1k.com -w /tmp/small
[-] Unable to connect: g0tmi1k.com/
[root:~/gobuster]#
```


### After 

```
[root:~/gobuster]# go run main.go -u g0tmi1k.com -w /tmp/small

=====================================================
Gobuster v0.9 (DIR support by OJ Reeves @TheColonial)
              (DNS support by Peleus     @0x42424242)
=====================================================
[+] Mode         : dir
[+] Url/Domain   : http://g0tmi1k.com/
[+] Threads      : 10
[+] Wordlist     : /tmp/small
[+] Status codes : 200,204,301,302,307
=====================================================
...SNIP...
=====================================================
[root:~/gobuster]#
```