### PR TITLE
Add basic auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Yes, you're probably correct. Feel free to :
 ### Command line options for `dir` mode
 
 * `-c <http cookies>` - use this to specify any cookies that you might need (simulating auth).
+* `-U <username>` - HTTP Authorization username (Only Basic Auth is supported for now)
+* `-P <password>` - HTTP Authorization password (Only Basic Auth is supported for now). If not supplied, you'll be prompted for it.
 * `-f` - append `/` for directory brute forces.
 * `-r` - follow redirects.
 * `-l` - show the length of the response.


### PR DESCRIPTION
I left room for alternate auth schemes to be added ala curl

`--basic` could be added, and be the default. `--ntlm` and `--digest` could be added to switch methods.