### PR TITLE
Implemented wildcard dir detection using the uuid approach

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,7 +254,7 @@ func ParseCmdLine() *State {
 	flag.BoolVar(&s.NoStatus, "n", false, "Don't print status codes")
 	flag.BoolVar(&s.IncludeLength, "l", false, "Include the length of the body in the output (dir mode only)")
 	flag.BoolVar(&s.UseSlash, "f", false, "Append a forward-slash to each directory request (dir mode only)")
-	flag.BoolVar(&s.WildcardForced, "fw", false, "Force continued operation when wildcard found (dns mode only)")
+	flag.BoolVar(&s.WildcardForced, "fw", false, "Force continued operation when wildcard found")
 
 	flag.Parse()
 
@@ -512,6 +512,18 @@ func SetupDns(s *State) bool {
 }
 
 func SetupDir(s *State) bool {
+	guid := uuid.NewV4()
+	wildcardResp, _ := GoGet(s, s.Url, fmt.Sprintf("%s", guid), s.Cookies)
+
+	if s.StatusCodes.Contains(*wildcardResp) {
+		s.IsWildcard = true
+		fmt.Println("[-] Wildcard response found:",fmt.Sprintf("%s%s", s.Url, guid), "=>", *wildcardResp)
+		if !s.WildcardForced {
+			fmt.Println("[-] To force processing of Wildcard responses, specify the '-fw' switch.")
+		}
+		return s.WildcardForced
+	}
+
 	return true
 }
 


### PR DESCRIPTION
Sample run:

```
$> ./gobuster -m dir -w directory-list-1.0.txt -t 1 -u 'https://wildcard.domain.tld/' -v 

Gobuster v1.2                OJ Reeves (@TheColonial)
=====================================================
[+] Mode         : dir
[+] Url/Domain   : https://wildcard.domain.tld/
[+] Threads      : 1
[+] Wordlist     : directory-list-1.0.txt
[+] Status codes : 302,307,200,204,301
[+] Verbose      : true
=====================================================
[-] Wildcard response found: https://wildcard.domain.tld/27ba698a-9ceb-4600-b074-f2ce87a4865e => 200
[-] To force processing of Wildcard responses, specify the '-fw' switch.
=====================================================
```

and 

```
$>  ./gobuster -m dir -w directory-list-1.0.txt -t 1 -u 'https://wildcard.domain.tld/' -v -fw

Gobuster v1.2                OJ Reeves (@TheColonial)
=====================================================
[+] Mode         : dir
[+] Url/Domain   : https://wildcard.domain.tld/
[+] Threads      : 1
[+] Wordlist     : directory-list-1.0.txt
[+] Status codes : 302,307,200,204,301
[+] Verbose      : true
=====================================================
[-] Wildcard response found: https://wildcard.domain.tld/1fe80eb4-d537-494e-8112-65c5a6809969 => 200
^C[!] Keyboard interrupt detected, terminating.
Found : /cgi-bin (Status: 200)
Found : /education (Status: 200)
Found : /betsie (Status: 200)
=====================================================
```

You might want to adjust the info messages. 

Closes #26
