### PR TITLE
Implemented switch for URL protocols

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@ package main
 // Please see LICENSE file for license details.
 //
 //----------------------------------------------------
-
 import (
 	"bufio"
 	"crypto/tls"
@@ -71,6 +70,7 @@ type State struct {
 	Mode           string
 	NoStatus       bool
 	Password       string
+	Protocol       string
 	Printer        PrintResultFunc
 	Processor      ProcessorFunc
 	ProxyUrl       *url.URL
@@ -240,6 +240,7 @@ func ParseCmdLine() *State {
 	flag.StringVar(&s.Wordlist, "w", "", "Path to the wordlist")
 	flag.StringVar(&codes, "s", "200,204,301,302,307", "Positive status codes (dir mode only)")
 	flag.StringVar(&s.Url, "u", "", "The target URL or Domain")
+	flag.StringVar(&s.Protocol, "pr", "http://", "The target URL's protocol (dir mode only)")
 	flag.StringVar(&s.Cookies, "c", "", "Cookies to use for the requests (dir mode only)")
 	flag.StringVar(&s.Username, "U", "", "Username for Basic Auth (dir mode only)")
 	flag.StringVar(&s.Password, "P", "", "Password for Basic Auth (dir mode only)")
@@ -310,7 +311,7 @@ func ParseCmdLine() *State {
 		}
 
 		if strings.HasPrefix(s.Url, "http") == false {
-			s.Url = "http://" + s.Url
+			s.Url = s.Protocol + s.Url
 		}
 
 		// extensions are comma separated


### PR DESCRIPTION
Hi,

another PR of an useful feature (at least for me): A cmdline switch for the URL protocol (dir mode). 

I usually run gobuster on multiple domains in a for loop. This makes it more convenient, because I don't have to fiddle around and manually build the correct `-u` parameter. 

I'm not sure about the `-pr` switch name, though.

Sample runs:

```
$> ./gobuster  -m dir -w wordlist -u gehaxelt.in 

Gobuster v1.2                OJ Reeves (@TheColonial)
=====================================================
[+] Mode         : dir
[+] Url/Domain   : http://gehaxelt.in/
[+] Threads      : 10
[+] Wordlist     : wordlist
[+] Status codes : 200,204,301,302,307
=====================================================
/.git/HEAD (Status: 301)
=====================================================
```

and 

```
$> ./gobuster  -m dir -w wordlist -u gehaxelt.in -pr https:// 

Gobuster v1.2                OJ Reeves (@TheColonial)
=====================================================
[+] Mode         : dir
[+] Url/Domain   : https://gehaxelt.in/
[+] Threads      : 10
[+] Wordlist     : wordlist
[+] Status codes : 200,204,301,302,307
=====================================================
/.git/HEAD (Status: 301)
=====================================================
```

Kind regards