### PR TITLE
Add cli flag to skip ssl verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Yes, you're probably correct. Feel free to:
 * `-x <extensions>` - list of extensions to check for, if any.
 * `-P <password>` - HTTP Authorization password (Basic Auth only, prompted if missing).
 * `-U <username>` - HTTP Authorization username (Basic Auth only).
+* `-is` - Skip verification of SSL certificates.
 
 ### Building
 

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ type State struct {
 	SignalChan     chan os.Signal
 	Terminate      bool
 	StdIn          bool
+	InsecureSSL    bool
 }
 
 type RedirectHandler struct {
@@ -187,6 +188,11 @@ func MakeRequest(s *State, fullUrl, cookie string) (*int, *int64) {
 
 	if err != nil {
 		if ue, ok := err.(*url.Error); ok {
+
+			if strings.HasPrefix(ue.Err.Error(), "x509") {
+				fmt.Println("[-] Invalid certificate")
+			}
+
 			if re, ok := ue.Err.(*RedirectError); ok {
 				return &re.StatusCode, nil
 			}
@@ -255,6 +261,7 @@ func ParseCmdLine() *State {
 	flag.BoolVar(&s.IncludeLength, "l", false, "Include the length of the body in the output (dir mode only)")
 	flag.BoolVar(&s.UseSlash, "f", false, "Append a forward-slash to each directory request (dir mode only)")
 	flag.BoolVar(&s.WildcardForced, "fw", false, "Force continued operation when wildcard found (dns mode only)")
+	flag.BoolVar(&s.InsecureSSL, "is", false, "Skip SSL certificate verification")
 
 	flag.Parse()
 
@@ -372,7 +379,7 @@ func ParseCmdLine() *State {
 					Transport: &http.Transport{
 						Proxy: proxyUrlFunc,
 						TLSClientConfig: &tls.Config{
-							InsecureSkipVerify: true,
+							InsecureSkipVerify: s.InsecureSSL,
 						},
 					},
 				}}


### PR DESCRIPTION
This PR adds a cli flag to skip ssl certificate verification. Related to #22.
