### PR TITLE
Add feature to get HTTP OPTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Yes, you're probably correct. Feel free to:
 * `-k` - Skip verification of SSL certificates.
 * `-l` - show the length of the response.
 * `-n` - "no status" mode, disables the output of the result's status code.
+* `-methods` Show HTTP methods support by the server at that URL. Good for exposing WebDAV support.
 * `-o <file>` - specify a file name to write the output to.
 * `-p <proxy url>` - specify a proxy to use for all requests (scheme much match the URL scheme).
 * `-r` - follow redirects.

--- a/libgobuster/helpers.go
+++ b/libgobuster/helpers.go
@@ -77,6 +77,10 @@ func ShowConfig(s *State) {
 				fmt.Printf("[+] Show length  : true\n")
 			}
 
+			if s.IncludeOptions {
+				fmt.Printf("[+] Show Methods : true\n")
+			}
+
 			if s.Username != "" {
 				fmt.Printf("[+] Auth User    : %s\n", s.Username)
 			}

--- a/libgobuster/state.go
+++ b/libgobuster/state.go
@@ -13,10 +13,11 @@ import (
 // A single result which comes from an individual web
 // request.
 type Result struct {
-	Entity string
-	Status int
-	Extra  string
-	Size   *int64
+	Entity  string
+	Status  int
+	Extra   string
+	Size    *int64
+	Options *[]string
 }
 
 type PrintResultFunc func(s *State, r *Result)
@@ -42,6 +43,7 @@ type State struct {
 	Extensions     []string
 	FollowRedirect bool
 	IncludeLength  bool
+	IncludeOptions bool
 	Mode           string
 	NoStatus       bool
 	Password       string

--- a/libgobuster/statehelpers.go
+++ b/libgobuster/statehelpers.go
@@ -19,8 +19,6 @@ package libgobuster
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
-	"golang.org/x/crypto/ssh/terminal"
 	"net/http"
 	"net/url"
 	"os"
@@ -28,6 +26,9 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func InitState() State {
@@ -195,7 +196,7 @@ func ValidateDirModeState(
 				},
 			}}
 
-		code, _ := GoGet(s, s.Url, "", s.Cookies)
+		code, _, _ := GoGet(s, s.Url, "", s.Cookies)
 		if code == nil {
 			errorList = multierror.Append(errorList, fmt.Errorf("[-] Unable to connect: %s", s.Url))
 		}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func ParseCmdLine() *libgobuster.State {
 	flag.BoolVar(&s.Expanded, "e", false, "Expanded mode, print full URLs")
 	flag.BoolVar(&s.NoStatus, "n", false, "Don't print status codes")
 	flag.BoolVar(&s.IncludeLength, "l", false, "Include the length of the body in the output (dir mode only)")
-	flag.BoolVar(&s.IncludeOptions, "opt", false, "Include the possible HTTP methods in the output (dir mode only)")
+	flag.BoolVar(&s.IncludeOptions, "methods", false, "Include the possible HTTP methods in the output (dir mode only)")
 	flag.BoolVar(&s.UseSlash, "f", false, "Append a forward-slash to each directory request (dir mode only)")
 	flag.BoolVar(&s.WildcardForced, "fw", false, "Force continued operation when wildcard found")
 	flag.BoolVar(&s.InsecureSSL, "k", false, "Skip SSL certificate verification")

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func ParseCmdLine() *libgobuster.State {
 	flag.BoolVar(&s.Expanded, "e", false, "Expanded mode, print full URLs")
 	flag.BoolVar(&s.NoStatus, "n", false, "Don't print status codes")
 	flag.BoolVar(&s.IncludeLength, "l", false, "Include the length of the body in the output (dir mode only)")
+	flag.BoolVar(&s.IncludeOptions, "opt", false, "Include the possible HTTP methods in the output (dir mode only)")
 	flag.BoolVar(&s.UseSlash, "f", false, "Append a forward-slash to each directory request (dir mode only)")
 	flag.BoolVar(&s.WildcardForced, "fw", false, "Force continued operation when wildcard found")
 	flag.BoolVar(&s.InsecureSSL, "k", false, "Skip SSL certificate verification")


### PR DESCRIPTION
This adds a `-opt` feature to reveal HTTP OPTIONS.
I needed to be able to find dav shares for a CTF.
I didn't find any other tool that would do this, so I modified gobuster.