### PR TITLE
Add ability to bust with placeholders.

### DIFF
--- a/libgobuster/dir.go
+++ b/libgobuster/dir.go
@@ -136,6 +136,21 @@ func ProcessDirEntry(s *State, word string, resultChan chan<- Result) {
 		}
 	}
 
+	if s.Placeholder != "" {
+
+		replacedURL := strings.Replace(s.Url, s.Placeholder, word, -1)
+		replacedURL = strings.TrimRight(replacedURL, "/") // halp! where does the trailing / come from?
+
+		dirResp, dirSize := GoGet(s, replacedURL, "", s.Cookies)
+		if dirResp != nil {
+			resultChan <- Result{
+				Entity: "(replaced " + s.Placeholder + " with " + word + ")",
+				Status: *dirResp,
+				Size:   dirSize,
+			}
+		}
+	}
+
 	// Follow up with files using each ext.
 	for ext := range s.Extensions {
 		file := word + s.Extensions[ext]

--- a/libgobuster/state.go
+++ b/libgobuster/state.go
@@ -40,6 +40,7 @@ type State struct {
 	Cookies        string
 	Expanded       bool
 	Extensions     []string
+	Placeholder    string
 	FollowRedirect bool
 	IncludeLength  bool
 	Mode           string

--- a/libgobuster/statehelpers.go
+++ b/libgobuster/statehelpers.go
@@ -19,8 +19,6 @@ package libgobuster
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
-	"golang.org/x/crypto/ssh/terminal"
 	"net/http"
 	"net/url"
 	"os"
@@ -28,6 +26,9 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func InitState() State {
@@ -199,6 +200,11 @@ func ValidateDirModeState(
 		if code == nil {
 			errorList = multierror.Append(errorList, fmt.Errorf("[-] Unable to connect: %s", s.Url))
 		}
+	}
+
+	// Ensure that a given placeholder exists in a URL
+	if s.Placeholder != "" && !strings.Contains(s.Url, s.Placeholder) {
+		errorList = multierror.Append(errorList, fmt.Errorf("[!] Placeholder given but not present in target URL"))
 	}
 
 	return errorList

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func ParseCmdLine() *libgobuster.State {
 	flag.StringVar(&s.Mode, "m", "dir", "Directory/File mode (dir) or DNS mode (dns)")
 	flag.StringVar(&s.Wordlist, "w", "", "Path to the wordlist")
 	flag.StringVar(&codes, "s", "200,204,301,302,307", "Positive status codes (dir mode only)")
+	flag.StringVar(&s.Placeholder, "ph", "", "A placeholder string to search for string replacements in URLs (dir mode only)")
 	flag.StringVar(&s.OutputFileName, "o", "", "Output file to write results to (defaults to stdout)")
 	flag.StringVar(&s.Url, "u", "", "The target URL or Domain")
 	flag.StringVar(&s.Cookies, "c", "", "Cookies to use for the requests (dir mode only)")


### PR DESCRIPTION
## proposal 

This commit adds the ability to define placeholder keywords in a URL and have those replaced with words defined by stdin or a wordlist.

An example use would be:

```
$ gobuster -w wordlist -u http://localhost:8000/BUSTbar.txt -ph BUST -v -e
Missed: http://localhost:8000/BUSTbar.txt/foo (Status: 404)
Missed: http://localhost:8000/BUSTbar.txt/bar (Status: 404)
Missed: http://localhost:8000/BUSTbar.txt/baz (Status: 404)
Found : http://localhost:8000/BUSTbar.txt/(replaced BUST with foo) (Status: 200)
Missed: http://localhost:8000/BUSTbar.txt/(replaced BUST with baz) (Status: 404)
Missed: http://localhost:8000/BUSTbar.txt/(replaced BUST with bar) (Status: 404)
```

A URL such as http://localhost:8000/BUSTbarBUST.txt will have the processor replace both instances of the BUST placeholder word.

## Problems:
Printing matched results is not great. Ideally one would like to see something like the following output: `Found: foobar.txt (Status: 200)`. Before I go and get a fresh bit of sticky tape and gum, is there a preferred way to handle this?
I also can't seem to find where the trailing slash is appended to the URL, even though I have not specified `-f`.