### PR TITLE
Added negative status code option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Yes, you're probably correct. Feel free to:
 * `-p <proxy url>` - specify a proxy to use for all requests (scheme much match the URL scheme).
 * `-r` - follow redirects.
 * `-s <status codes>` - comma-separated set of the list of status codes to be deemed a "positive" (default: `200,204,301,302,307`).
+* `-S <status codes>` - comma-separated set of the list of status codes to be deemed to be a "negative" (no default; cannot be used with "-s"; overrides "-s")
 * `-x <extensions>` - list of extensions to check for, if any.
 * `-P <password>` - HTTP Authorization password (Basic Auth only, prompted if missing).
 * `-U <username>` - HTTP Authorization username (Basic Auth only).

--- a/libgobuster/helpers.go
+++ b/libgobuster/helpers.go
@@ -59,7 +59,11 @@ func ShowConfig(s *State) {
 		}
 
 		if s.Mode == "dir" {
-			fmt.Printf("[+] Status codes : %s\n", s.StatusCodes.Stringify())
+			if s.NegStatusCodes.Stringify() == "" {
+				fmt.Printf("[+] Status codes : %s\n", s.StatusCodes.Stringify())
+			} else {
+				fmt.Printf("[+] Negative status codes: %s\n", s.NegStatusCodes.Stringify())
+			}
 
 			if s.ProxyUrl != nil {
 				fmt.Printf("[+] Proxy        : %s\n", s.ProxyUrl)

--- a/libgobuster/state.go
+++ b/libgobuster/state.go
@@ -53,6 +53,7 @@ type State struct {
 	ShowIPs        bool
 	ShowCNAME      bool
 	StatusCodes    IntSet
+	NegStatusCodes    IntSet
 	Threads        int
 	Url            string
 	UseSlash       bool

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 func ParseCmdLine() *libgobuster.State {
 	var extensions string
 	var codes string
+	var negcodes string
 	var proxy string
 
 	s := libgobuster.InitState()
@@ -37,6 +38,7 @@ func ParseCmdLine() *libgobuster.State {
 	flag.StringVar(&s.Mode, "m", "dir", "Directory/File mode (dir) or DNS mode (dns)")
 	flag.StringVar(&s.Wordlist, "w", "", "Path to the wordlist")
 	flag.StringVar(&codes, "s", "200,204,301,302,307", "Positive status codes (dir mode only)")
+	flag.StringVar(&negcodes, "S", "", "Negative status codes (dir mode only) (can't be used with \"-s\") (overrides \"-s\")")
 	flag.StringVar(&s.OutputFileName, "o", "", "Output file to write results to (defaults to stdout)")
 	flag.StringVar(&s.Url, "u", "", "The target URL or Domain")
 	flag.StringVar(&s.Cookies, "c", "", "Cookies to use for the requests (dir mode only)")
@@ -61,7 +63,7 @@ func ParseCmdLine() *libgobuster.State {
 
 	libgobuster.Banner(&s)
 
-	if err := libgobuster.ValidateState(&s, extensions, codes, proxy); err.ErrorOrNil() != nil {
+	if err := libgobuster.ValidateState(&s, extensions, codes, negcodes, proxy); err.ErrorOrNil() != nil {
 		fmt.Printf("%s\n", err.Error())
 		return nil
 	} else {


### PR DESCRIPTION
I've added "-S" to define negative status codes (instead of "-s").
There are no defaults for "-S".
If "-S" is specified, the values provided will overwrite the "-s" defaults (or any values specified by the user for "-s").

Example would be...
gobuster -m dir -w words -u http://host/ -S 404

*fingers crossed* This is literally my first pull request ever.  I hope it is OK.