### PR TITLE
Arbitrary headers, POST support, POST body support, Content-Type support, linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 *.prof
 *.txt
 *.swp
+
+# The executable, if it has been built
+gobuster

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Yes, you're probably correct. Feel free to:
 * `-P <password>` - HTTP Authorization password (Basic Auth only, prompted if missing).
 * `-U <username>` - HTTP Authorization username (Basic Auth only).
 * `-H <header1: value|header2: value|header3: value` - HTTP headers to add to the request
-* `-X <verb>` - Verb to use instead of GET (GET, POST are supported, default is GET)
-* `-b <body string>` - String to use as the POST body. Use $'xxx' in the shell for best results
-* `-ct <content type>` - Content-Type header value for POST requests, i.e. application/json
+* `-X <verb>` - Verb to use instead of GET (GET, POST, OPTIONS, PUT are supported, default is GET)
+* `-b <body string>` - String to use as the POST, PUT body. Use $'xxx' in the shell for best results
+* `-ct <content type>` - Content-Type header value for POST, PUT requests, i.e. application/json
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Yes, you're probably correct. Feel free to:
 
 * Not use it.
 * Show me how to do it better.
+* The code has been gometalint'd as of 3/4/2018 so calm down :>
 
 ### Common Command line options
 
@@ -58,6 +59,10 @@ Yes, you're probably correct. Feel free to:
 * `-x <extensions>` - list of extensions to check for, if any.
 * `-P <password>` - HTTP Authorization password (Basic Auth only, prompted if missing).
 * `-U <username>` - HTTP Authorization username (Basic Auth only).
+* `-H <header1: value|header2: value|header3: value` - HTTP headers to add to the request
+* `-X <verb>` - Verb to use instead of GET (GET, POST are supported, default is GET)
+* `-b <body string>` - String to use as the POST body. Use $'xxx' in the shell for best results
+* `-ct <content type>` - Content-Type header value for POST requests, i.e. application/json
 
 ### Building
 
@@ -128,6 +133,26 @@ Gobuster v1.4.1              OJ Reeves (@TheColonial)
 /contact
 =====================================================
 ```
+
+Calling a JSON API would look like this:
+```
+$ ./gobuster.git -u http://localhost/api/v1/ -X POST -b '{"test": "test"}' -w api-method-wordlist.txt -ct application/json
+
+Gobuster v1.4.1              OJ Reeves (@TheColonial)
+=====================================================
+=====================================================
+[+] Mode         : dir
+[+] URL/Domain   : http://localhost/api/vi/
+[+] Threads      : 10
+[+] Wordlist     : ../raft-medium-directories.txt
+[+] Status codes : 302,307,200,204,301
+=====================================================
+=====================================================
+/api/v1/login
+...
+$
+```
+
 Verbose output looks like this:
 ```
 $ gobuster -u http://buffered.io/ -w words.txt -v

--- a/THANKS
+++ b/THANKS
@@ -12,3 +12,4 @@
 @knapsy - saving output to file, and CNAME resolution for DNS mode
 @rverton - CLI flag to skip SSL verification
 @viaMorgoth - base domain validation for DNS mode
+@mzpqnxow - extensive linting, arbitrary headers, arbitrary verbs, HTTP body, ...

--- a/libgobuster/dns.go
+++ b/libgobuster/dns.go
@@ -8,10 +8,10 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-func SetupDns(s *State) bool {
-	// Resolve a subdomain that probably shouldn't exist
+// SetupDNS ... Resolve a subdomain that probably shouldn't exist
+func SetupDNS(s *State) bool {
 	guid := uuid.Must(uuid.NewV4())
-	wildcardIps, err := net.LookupHost(fmt.Sprintf("%s.%s", guid, s.Url))
+	wildcardIps, err := net.LookupHost(fmt.Sprintf("%s.%s", guid, s.URL))
 	if err == nil {
 		s.IsWildcard = true
 		s.WildcardIps.AddRange(wildcardIps)
@@ -24,18 +24,19 @@ func SetupDns(s *State) bool {
 
 	if !s.Quiet {
 		// Provide a warning if the base domain doesn't resolve (in case of typo)
-		_, err = net.LookupHost(s.Url)
+		_, err = net.LookupHost(s.URL)
 		if err != nil {
 			// Not an error, just a warning. Eg. `yp.to` doesn't resolve, but `cr.py.to` does!
-			fmt.Println("[-] Unable to validate base domain:", s.Url)
+			fmt.Println("[-] Unable to validate base domain:", s.URL)
 		}
 	}
 
 	return true
 }
 
-func ProcessDnsEntry(s *State, word string, resultChan chan<- Result) {
-	subdomain := word + "." + s.Url
+// ProcessDNSEntry ... Make a DNS request to a domain from the wordlist
+func ProcessDNSEntry(s *State, word string, resultChan chan<- Result) {
+	subdomain := word + "." + s.URL
 	ips, err := net.LookupHost(subdomain)
 
 	if err == nil {
@@ -62,7 +63,8 @@ func ProcessDnsEntry(s *State, word string, resultChan chan<- Result) {
 	}
 }
 
-func PrintDnsResult(s *State, r *Result) {
+// PrintDNSResult ... Print out various metadata about the DNS response
+func PrintDNSResult(s *State, r *Result) {
 	output := ""
 	if r.Status == 404 {
 		output = fmt.Sprintf("Missing: %s\n", r.Entity)

--- a/libgobuster/helpers.go
+++ b/libgobuster/helpers.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 )
 
+// PrepareSignalHandler ... Set up a SIGINT handler
 func PrepareSignalHandler(s *State) {
 	s.SignalChan = make(chan os.Signal, 1)
 	signal.Notify(s.SignalChan, os.Interrupt)
 	go func() {
-		for _ = range s.SignalChan {
+		for range s.SignalChan {
 			// caught CTRL+C
 			if !s.Quiet {
 				fmt.Println("[!] Keyboard interrupt detected, terminating.")
@@ -22,12 +23,14 @@ func PrepareSignalHandler(s *State) {
 	}()
 }
 
+// Ruler ... Perform advanced screen I/O :>
 func Ruler(s *State) {
 	if !s.Quiet {
 		fmt.Println("=====================================================")
 	}
 }
 
+// Banner ... Print the Gobuster banner to the screen
 func Banner(s *State) {
 	if s.Quiet {
 		return
@@ -38,6 +41,7 @@ func Banner(s *State) {
 	Ruler(s)
 }
 
+// ShowConfig ... Print the state to the screen
 func ShowConfig(s *State) {
 	if s.Quiet {
 		return
@@ -45,7 +49,7 @@ func ShowConfig(s *State) {
 
 	if s != nil {
 		fmt.Printf("[+] Mode         : %s\n", s.Mode)
-		fmt.Printf("[+] Url/Domain   : %s\n", s.Url)
+		fmt.Printf("[+] URL/Domain   : %s\n", s.URL)
 		fmt.Printf("[+] Threads      : %d\n", s.Threads)
 
 		wordlist := "stdin (pipe)"
@@ -61,8 +65,8 @@ func ShowConfig(s *State) {
 		if s.Mode == "dir" {
 			fmt.Printf("[+] Status codes : %s\n", s.StatusCodes.Stringify())
 
-			if s.ProxyUrl != nil {
-				fmt.Printf("[+] Proxy        : %s\n", s.ProxyUrl)
+			if s.ProxyURL != nil {
+				fmt.Printf("[+] Proxy        : %s\n", s.ProxyURL)
 			}
 
 			if s.Cookies != "" {
@@ -110,27 +114,27 @@ func ShowConfig(s *State) {
 	}
 }
 
-// Add an element to a set
+// Add ... Add an element to a set
 func (set *StringSet) Add(s string) bool {
 	_, found := set.Set[s]
 	set.Set[s] = true
 	return !found
 }
 
-// Add a list of elements to a set
+// AddRange ... Add a list of elements to a set
 func (set *StringSet) AddRange(ss []string) {
 	for _, s := range ss {
 		set.Set[s] = true
 	}
 }
 
-// Test if an element is in a set
+// Contains ... Test if an element is in a set
 func (set *StringSet) Contains(s string) bool {
 	_, found := set.Set[s]
 	return found
 }
 
-// Check if any of the elements exist
+// ContainsAny ... Check if any of the elements exist
 func (set *StringSet) ContainsAny(ss []string) bool {
 	for _, s := range ss {
 		if set.Set[s] {
@@ -140,32 +144,32 @@ func (set *StringSet) ContainsAny(ss []string) bool {
 	return false
 }
 
-// Stringify the set
+// Stringify ... Stringify the set
 func (set *StringSet) Stringify() string {
 	values := []string{}
-	for s, _ := range set.Set {
+	for s := range set.Set {
 		values = append(values, s)
 	}
 	return strings.Join(values, ",")
 }
 
-// Add an element to a set
+// Add ... Add an element to a set
 func (set *IntSet) Add(i int) bool {
 	_, found := set.Set[i]
 	set.Set[i] = true
 	return !found
 }
 
-// Test if an element is in a set
+// Contains ... Test if an element is in a set
 func (set *IntSet) Contains(i int) bool {
 	_, found := set.Set[i]
 	return found
 }
 
-// Stringify the set
+// Stringify ... Stringify the set
 func (set *IntSet) Stringify() string {
 	values := []string{}
-	for s, _ := range set.Set {
+	for s := range set.Set {
 		values = append(values, strconv.Itoa(s))
 	}
 	return strings.Join(values, ",")

--- a/libgobuster/output.go
+++ b/libgobuster/output.go
@@ -1,5 +1,6 @@
 package libgobuster
 
+// WriteToFile ... Output a string to a file in the global State
 func WriteToFile(output string, s *State) {
 	_, err := s.OutputFile.WriteString(output)
 	if err != nil {

--- a/libgobuster/state.go
+++ b/libgobuster/state.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 )
 
-// A single result which comes from an individual web
+// Result ...A single result which comes from an individual web
 // request.
 type Result struct {
 	Entity string
@@ -19,27 +19,33 @@ type Result struct {
 	Size   *int64
 }
 
+// PrintResultFunc ...
 type PrintResultFunc func(s *State, r *Result)
+// ProcessorFunc ...
 type ProcessorFunc func(s *State, entity string, resultChan chan<- Result)
+// SetupFunc ...
 type SetupFunc func(s *State) bool
 
-// Shim type for "set" containing ints
+// IntSet ... Shim type for "set" containing ints
 type IntSet struct {
 	Set map[int]bool
 }
 
-// Shim type for "set" containing strings
+// StringSet ... Shim type for "set" containing strings
 type StringSet struct {
 	Set map[string]bool
 }
 
-// Contains State that are read in from the command
+// State ... Contains State that are read in from the command
 // line when the program is invoked.
 type State struct {
+	Body	       string
 	Client         *http.Client
 	Cookies        string
+	ContentType    string
 	Expanded       bool
 	Extensions     []string
+	Headers		   string
 	FollowRedirect bool
 	IncludeLength  bool
 	Mode           string
@@ -47,14 +53,15 @@ type State struct {
 	Password       string
 	Printer        PrintResultFunc
 	Processor      ProcessorFunc
-	ProxyUrl       *url.URL
+	ProxyURL       *url.URL
 	Quiet          bool
+	Request		   *http.Request
 	Setup          SetupFunc
 	ShowIPs        bool
 	ShowCNAME      bool
 	StatusCodes    IntSet
 	Threads        int
-	Url            string
+	URL            string
 	UseSlash       bool
 	UserAgent      string
 	Username       string
@@ -69,6 +76,7 @@ type State struct {
 	Terminate      bool
 	StdIn          bool
 	InsecureSSL    bool
+	Verb           string
 }
 
 // Process the busting of the website with the given
@@ -77,7 +85,7 @@ func Process(s *State) {
 
 	ShowConfig(s)
 
-	if s.Setup(s) == false {
+	if !s.Setup(s) {
 		Ruler(s)
 		return
 	}

--- a/libgobuster/statehelpers.go
+++ b/libgobuster/statehelpers.go
@@ -44,7 +44,9 @@ func InitState() State {
 func ValidVerb(verb string) bool {
 	switch verb {
     case
+    	"OPTIONS",
         "GET",
+        "PUT",
         "POST":
         return true
     default:
@@ -170,12 +172,12 @@ func validateDirModeState(
     	errorList = multierror.Append(errorList, fmt.Errorf("[!] Headers (-H): Invalid value: %s", s.Headers))
     }
 
-    if s.Verb == "GET" && s.Body != "" {
-    	errorList = multierror.Append(errorList, fmt.Errorf("[!] Body (-b): GET request has no body"))
+    if (s.Verb == "GET" || s.Verb == "OPTIONS") && s.Body != "" {
+    	errorList = multierror.Append(errorList, fmt.Errorf("[!] Body (-b): GET and OPTIONS requests have no body"))
     }
 
-    if s.Verb == "GET" && s.ContentType != "" {
-    	errorList = multierror.Append(errorList, fmt.Errorf("[!] Content-Type (-ct): GET request has no Content-Type"))
+    if (s.Verb == "GET" || s.Verb == "OPTIONS") && s.ContentType != "" {
+    	errorList = multierror.Append(errorList, fmt.Errorf("[!] Content-Type (-ct): GET and OPTIONS requests have no Content-Type"))
     }
 
 	// extensions are comma separated

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func ParseCmdLine() *libgobuster.State {
 	flag.StringVar(&s.UserAgent, "a", "", "Set the User-Agent string (dir mode only)")
 	flag.StringVar(&proxy, "p", "", "Proxy to use for requests [http(s)://host:port] (dir mode only)")
 	flag.StringVar(&s.ContentType, "ct", "", "Default Content-Type for POST requests")
-	flag.StringVar(&s.Verb, "X", "GET", "Verb to use instead of GET (GET, POST are valid)")
+	flag.StringVar(&s.Verb, "X", "GET", "Verb to use instead of GET (GET, POST, PUT) are valid)")
 	flag.StringVar(&s.Body, "b", "", "Content of POST body, i.e. '{}' for Application/JSON")
 	flag.StringVar(&s.Headers, "H", "", "List of arbitrary headers to supply, separated by '|' characters")
 	flag.BoolVar(&s.Verbose, "v", false, "Verbose output (errors)")

--- a/main.go
+++ b/main.go
@@ -19,11 +19,11 @@ package main
 import (
 	"flag"
 	"fmt"
-
-	"github.com/OJ/gobuster/libgobuster"
+	"./libgobuster"
+	//"github.com/mzpqnxow/gobuster/libgobuster"
 )
 
-// Parse all the command line options into a settings
+// ParseCmdLine ... Parse all the command line options into a settings
 // instance for future use.
 func ParseCmdLine() *libgobuster.State {
 	var extensions string
@@ -38,13 +38,17 @@ func ParseCmdLine() *libgobuster.State {
 	flag.StringVar(&s.Wordlist, "w", "", "Path to the wordlist")
 	flag.StringVar(&codes, "s", "200,204,301,302,307", "Positive status codes (dir mode only)")
 	flag.StringVar(&s.OutputFileName, "o", "", "Output file to write results to (defaults to stdout)")
-	flag.StringVar(&s.Url, "u", "", "The target URL or Domain")
+	flag.StringVar(&s.URL, "u", "", "The target URL or Domain")
 	flag.StringVar(&s.Cookies, "c", "", "Cookies to use for the requests (dir mode only)")
 	flag.StringVar(&s.Username, "U", "", "Username for Basic Auth (dir mode only)")
 	flag.StringVar(&s.Password, "P", "", "Password for Basic Auth (dir mode only)")
 	flag.StringVar(&extensions, "x", "", "File extension(s) to search for (dir mode only)")
 	flag.StringVar(&s.UserAgent, "a", "", "Set the User-Agent string (dir mode only)")
 	flag.StringVar(&proxy, "p", "", "Proxy to use for requests [http(s)://host:port] (dir mode only)")
+	flag.StringVar(&s.ContentType, "ct", "", "Default Content-Type for POST requests")
+	flag.StringVar(&s.Verb, "X", "GET", "Verb to use instead of GET (GET, POST are valid)")
+	flag.StringVar(&s.Body, "b", "", "Content of POST body, i.e. '{}' for Application/JSON")
+	flag.StringVar(&s.Headers, "H", "", "List of arbitrary headers to supply, separated by '|' characters")
 	flag.BoolVar(&s.Verbose, "v", false, "Verbose output (errors)")
 	flag.BoolVar(&s.ShowIPs, "i", false, "Show IP addresses (dns mode only)")
 	flag.BoolVar(&s.ShowCNAME, "cn", false, "Show CNAME records (dns mode only, cannot be used with '-i' option)")
@@ -64,10 +68,10 @@ func ParseCmdLine() *libgobuster.State {
 	if err := libgobuster.ValidateState(&s, extensions, codes, proxy); err.ErrorOrNil() != nil {
 		fmt.Printf("%s\n", err.Error())
 		return nil
-	} else {
-		libgobuster.Ruler(&s)
-		return &s
 	}
+
+	libgobuster.Ruler(&s)
+	return &s
 }
 
 func main() {


### PR DESCRIPTION
Hi, I use gobuster quite a bit as it is a simple and very fast tool for enumerating files and directories. There were some limitations that I wanted to deal with though- specifically, gobuster would not find even the most obviously named API endpoints, despite the method names being in the wordlist. This turned out to be because they required either a different HTTP verb (i.e. POST) or they required a special Content-Type (i.e. application/json)

I've added support for these things, including the ability to specify a POST body on the command-line. If I have a spare few moments I think it would be nice to support curl style `-b @filename.json` to put the POST body contents in a file since the command-line can be a little clunky.

Your README comments on the poor style of the code; I didn't find it to be all that bad, but I did spend about an hour linting it extensively with `gometalinter` - I thought you might appreciate that. You can go through the diffs and spot the cleanups. Many of them were just adding `FunctionName ... <comments>` to the headers of all exported functions, though there were quite a few other legitimate cleanups.

Apologies in advance for not splitting out the commits better, I know this is a large PR

Also note you will likely want to change the import ./libgobuster back to github.com/OJ/gobuster/libgobuster if you accept this PR. Because there were heavy changes to libgobuster and not just main I had to work with the local copy of libgobuster. Then again, I'm not sure it matters

Let me know if you want to accept this, if you don't I will keep a fork for myself

Thx
A