### PR TITLE
Feature: numeric range expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Yes, you're probably correct. Feel free to:
 * `-u <url/domain>` - full URL (including scheme), or base domain name.
 * `-v` - verbose output (show all results).
 * `-w <wordlist>` - path to the wordlist used for brute forcing.
-* `-xr` - expand numeric ranges in wordlist (example:foo-[1-10]).
+* `-xr` - expand numeric ranges in wordlist (example: foo-[1-10]).
 
 ### Command line options for `dns` mode
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Yes, you're probably correct. Feel free to:
 * `-u <url/domain>` - full URL (including scheme), or base domain name.
 * `-v` - verbose output (show all results).
 * `-w <wordlist>` - path to the wordlist used for brute forcing.
+* `-xr` - expand numeric ranges in wordlist (example:foo-[1-10]).
 
 ### Command line options for `dns` mode
 

--- a/libgobuster/state.go
+++ b/libgobuster/state.go
@@ -69,6 +69,7 @@ type State struct {
 	Terminate      bool
 	StdIn          bool
 	InsecureSSL    bool
+	ExpandRanges   bool
 }
 
 // Process the busting of the website with the given
@@ -107,8 +108,16 @@ func Process(s *State) {
 					break
 				}
 
-				// Mode-specific processing
-				s.Processor(s, word, resultChan)
+				if s.ExpandRanges == true {
+					parts := ParseTokens(word)
+					for _, expandedWord := range ExpandWords(parts) {
+						s.Processor(s, expandedWord, resultChan)
+					}
+
+				} else {
+					// Mode-specific processing
+					s.Processor(s, word, resultChan)
+				}
 			}
 
 			// Indicate to the wait group that the thread

--- a/libgobuster/wordranges.go
+++ b/libgobuster/wordranges.go
@@ -1,0 +1,75 @@
+package libgobuster
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+type RangeStringToken struct {
+	Text       string
+	IsRange    bool
+	RangeStart int
+	RangeEnd   int
+}
+
+func ParseTokens(word string) []RangeStringToken {
+	var tokens []RangeStringToken
+
+	pattern, _ := regexp.Compile(`\[(\d+)\-(\d+)\]|\.|([\w\-_\/]+)`)
+	matches := pattern.FindAllStringSubmatch(word, -1)
+
+	for _, match := range matches {
+		if match[1] == "" {
+			text := string(match[0])
+			tokens = append(tokens, RangeStringToken{Text: text, IsRange: false})
+		} else {
+			start, _ := strconv.Atoi(string(match[1]))
+			end, _ := strconv.Atoi(string(match[2]))
+
+			tokens = append(
+				tokens, RangeStringToken{
+					IsRange:    true,
+					RangeStart: start,
+					RangeEnd:   end})
+		}
+	}
+
+	return tokens
+}
+
+func ExpandWords(tokens []RangeStringToken) []string {
+	var expandedWords []string
+
+	for i, _ := range tokens {
+		var newWords []string
+		if tokens[i].IsRange {
+			if len(expandedWords) < 1 {
+				for j := tokens[i].RangeStart; j <= tokens[i].RangeEnd; j++ {
+					url := fmt.Sprintf("%s%d", "/", j)
+					newWords = append(newWords, url)
+				}
+			} else {
+				for _, expandedWord := range expandedWords {
+
+					for j := tokens[i].RangeStart; j <= tokens[i].RangeEnd; j++ {
+						url := fmt.Sprintf("%s%d", expandedWord, j)
+						newWords = append(newWords, url)
+					}
+				}
+
+			}
+		} else {
+			if len(expandedWords) < 1 {
+				newWords = append(newWords, tokens[i].Text)
+			} else {
+				for _, expandedWord := range expandedWords {
+					newWords = append(newWords, expandedWord+tokens[i].Text)
+				}
+			}
+
+		}
+		expandedWords = newWords
+	}
+	return expandedWords
+}

--- a/libgobuster/wordranges_test.go
+++ b/libgobuster/wordranges_test.go
@@ -1,0 +1,87 @@
+package libgobuster
+
+import "testing"
+
+// helper function
+func stringInList(s string, list []string) bool {
+	for _, item := range list {
+		if s == item {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestSingleNumericRange(t *testing.T) {
+	url := "/foo/bar/[1-5]/trailing"
+
+	expandedWords := ExpandWords(ParseTokens(url))
+	expectedNumWords := 5
+	numWords := len(expandedWords)
+	if numWords != expectedNumWords {
+		t.Errorf("Expected %d tokens, got %d", expectedNumWords, numWords)
+	}
+}
+
+func TestNoRange(t *testing.T) {
+	url := "/foo/bar/baz"
+
+	expandedWords := ExpandWords(ParseTokens(url))
+	if !stringInList(url, expandedWords) {
+		t.Errorf("Could not find literal %s in expanded Words", url)
+	}
+}
+
+func TestSingleWordWithRange(t *testing.T) {
+	url := "foo-[1-5]-[12-13]"
+
+	expandedWords := ExpandWords(ParseTokens(url))
+	expectedWords := 10
+	numWords := len(expandedWords)
+	if numWords != expectedWords {
+		t.Errorf("Expected %d tokens, got %d", expectedWords, numWords)
+	}
+}
+
+func TestDottedRange(t *testing.T) {
+	url := "foo-[1-5].[1-2].[12-13]"
+
+	expandedWords := ExpandWords(ParseTokens(url))
+	expectedWords := 20
+	numWords := len(expandedWords)
+	if numWords != expectedWords {
+		t.Errorf("Expected %d tokens, got %d", expectedWords, numWords)
+	}
+	expectedWord1 := "foo-3.2.12"
+	expectedWord2 := "foo-1.1.12"
+	expectedWord3 := "foo-5.2.13"
+	if !stringInList(expectedWord1, expandedWords) {
+		t.Errorf("Expected Word not found: %d", expectedWord1)
+	}
+	if !stringInList(expectedWord2, expandedWords) {
+		t.Errorf("Expected Word not found: %d", expectedWord2)
+	}
+	if !stringInList(expectedWord3, expandedWords) {
+		t.Errorf("Expected Word not found: %d", expectedWord3)
+	}
+}
+
+func TestMultipleNumericRange(t *testing.T) {
+	url := "/foo/bar/[1-5]/baz/[12-13]"
+
+	expandedWords := ExpandWords(ParseTokens(url))
+
+	if len(expandedWords) != 10 {
+		t.Errorf("Expected %d tokens, got %d", 10, len(expandedWords))
+	}
+
+	expectedWord1 := "/foo/bar/1/baz/12"
+	expectedWord2 := "/foo/bar/5/baz/13"
+	if !stringInList(expectedWord1, expandedWords) {
+		t.Errorf("Expected Word not found: %d", expectedWord1)
+	}
+	if !stringInList(expectedWord2, expandedWords) {
+		t.Errorf("Expected Word not found: %d", expectedWord2)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func ParseCmdLine() *libgobuster.State {
 	flag.BoolVar(&s.UseSlash, "f", false, "Append a forward-slash to each directory request (dir mode only)")
 	flag.BoolVar(&s.WildcardForced, "fw", false, "Force continued operation when wildcard found")
 	flag.BoolVar(&s.InsecureSSL, "k", false, "Skip SSL certificate verification")
+	flag.BoolVar(&s.ExpandRanges, "xr", false, "Expand words in wordlist that contain range patterns")
 
 	flag.Parse()
 


### PR DESCRIPTION
I've added a feature to gobuster to support numeric range expansion in words. For example, if you have an entry in a wordlist like this:

someapp-[1-3].[12-15].[1-2]

gobuster can now expand that word into a number of words, to scan for all combinations of the numeric ranges specified. For instance, the above pattern would expand into:

```
    someapp-1.12.1

    someapp-2.12.1

    someapp-3.12.1

    someapp-1.13.1

    ...
```
... and so on.

It also works for URLs (e.g. /foo/bar-[1-3].[12-15]) and DNS enumeration (www[1-100] and so on).

I've introduced a new command line parameter '-xr' to explicitly enable this feature, as it might be a bit more CPU intensive.

I've also added a number of unit tests for the feature, which can be found in libgobuster/wordranges_test.go , and they can be executed as such:

``
    cd libgobuster && go test -v
``
I've also adjusted the README.md to describe the new parameter.
