### PR TITLE
implement status on dir mode

### DIFF
--- a/libgobuster/dns.go
+++ b/libgobuster/dns.go
@@ -11,7 +11,7 @@ import (
 func SetupDns(s *State) bool {
 	// Resolve a subdomain that probably shouldn't exist
 	guid := uuid.Must(uuid.NewV4())
-	wildcardIps, err := net.LookupHost(fmt.Sprintf("%s.%s", guid, s.Url))
+	wildcardIps, err := net.LookupHost(fmt.Sprintf("%s.%s", guid, s.URL))
 	if err == nil {
 		s.IsWildcard = true
 		s.WildcardIps.AddRange(wildcardIps)
@@ -24,10 +24,10 @@ func SetupDns(s *State) bool {
 
 	if !s.Quiet {
 		// Provide a warning if the base domain doesn't resolve (in case of typo)
-		_, err = net.LookupHost(s.Url)
+		_, err = net.LookupHost(s.URL)
 		if err != nil {
 			// Not an error, just a warning. Eg. `yp.to` doesn't resolve, but `cr.py.to` does!
-			fmt.Println("[-] Unable to validate base domain:", s.Url)
+			fmt.Println("[-] Unable to validate base domain:", s.URL)
 		}
 	}
 
@@ -35,7 +35,7 @@ func SetupDns(s *State) bool {
 }
 
 func ProcessDnsEntry(s *State, word string, resultChan chan<- Result) {
-	subdomain := word + "." + s.Url
+	subdomain := fmt.Sprintf("%s.%s", word, s.URL)
 	ips, err := net.LookupHost(subdomain)
 
 	if err == nil {
@@ -63,7 +63,7 @@ func ProcessDnsEntry(s *State, word string, resultChan chan<- Result) {
 }
 
 func PrintDnsResult(s *State, r *Result) {
-	output := ""
+	var output string
 	if r.Status == 404 {
 		output = fmt.Sprintf("Missing: %s\n", r.Entity)
 	} else if s.ShowIPs {

--- a/libgobuster/output.go
+++ b/libgobuster/output.go
@@ -1,8 +1,12 @@
 package libgobuster
 
+import (
+	"fmt"
+)
+
 func WriteToFile(output string, s *State) {
 	_, err := s.OutputFile.WriteString(output)
 	if err != nil {
-		panic("[!] Unable to write to file " + s.OutputFileName)
+		panic(fmt.Sprintf("[!] Unable to write to file %s", s.OutputFileName))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func ParseCmdLine() *libgobuster.State {
 	flag.StringVar(&s.Wordlist, "w", "", "Path to the wordlist")
 	flag.StringVar(&codes, "s", "200,204,301,302,307", "Positive status codes (dir mode only)")
 	flag.StringVar(&s.OutputFileName, "o", "", "Output file to write results to (defaults to stdout)")
-	flag.StringVar(&s.Url, "u", "", "The target URL or Domain")
+	flag.StringVar(&s.URL, "u", "", "The target URL or Domain")
 	flag.StringVar(&s.Cookies, "c", "", "Cookies to use for the requests (dir mode only)")
 	flag.StringVar(&s.Username, "U", "", "Username for Basic Auth (dir mode only)")
 	flag.StringVar(&s.Password, "P", "", "Password for Basic Auth (dir mode only)")
@@ -64,10 +64,9 @@ func ParseCmdLine() *libgobuster.State {
 	if err := libgobuster.ValidateState(&s, extensions, codes, proxy); err.ErrorOrNil() != nil {
 		fmt.Printf("%s\n", err.Error())
 		return nil
-	} else {
-		libgobuster.Ruler(&s)
-		return &s
 	}
+	libgobuster.Ruler(&s)
+	return &s
 }
 
 func main() {

--- a/make_linux.bat
+++ b/make_linux.bat
@@ -1,0 +1,5 @@
+@echo off
+set GOOS=linux
+set GOARCH=amd64
+
+go build -o gobuster


### PR DESCRIPTION
This implements a progress output in dir mode.

I also changed some golint related stuff (mostly formatting)

Example run:
```
root@kali:~# ./gobuster -u http://10.1.1.1/ -w /usr/share/wordlists/dirb/common.txt 

Gobuster v1.4.1              OJ Reeves (@TheColonial)
=====================================================
=====================================================
[+] Mode         : dir
[+] Url/Domain   : http://10.1.1.1/
[+] Threads      : 10
[+] Wordlist     : /usr/share/wordlists/dirb/common.txt
[+] Status codes : 200,204,301,302,307
=====================================================
/index.html (Status: 200)
/robots.txt (Status: 200)
Status: 4613 / 4614
=====================================================
```