### PR TITLE
Added ability to search for files only

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Flags:
   -c, --cookies string                Cookies to use for the requests
   -e, --expanded                      Expanded mode, print full URLs
   -x, --extensions string             File extension(s) to search for
+  -X, --filesonly                     Search only for files in a known directory, skips directory search
   -r, --followredirect                Follow redirects
   -H, --headers stringArray           Specify HTTP headers, -H 'Header1: val1' -H 'Header2: val2'
   -h, --help                          help for dir

--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -119,6 +119,11 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 		return nil, nil, fmt.Errorf("invalid value for wildcard: %v", err)
 	}
 
+	plugin.FilesOnly, err = cmdDir.Flags().GetBool("filesonly")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for filesonly: %v", err)
+	}
+
 	return globalopts, plugin, nil
 }
 
@@ -140,6 +145,7 @@ func init() {
 	cmdDir.Flags().BoolP("includelength", "l", false, "Include the length of the body in the output")
 	cmdDir.Flags().BoolP("addslash", "f", false, "Apped / to each request")
 	cmdDir.Flags().BoolP("wildcard", "", false, "Force continued operation when wildcard found")
+	cmdDir.Flags().BoolP("filesonly", "X", false, "Search only for files in a known directory, skips directory search")
 
 	cmdDir.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		configureGlobalOptions()

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -18,6 +18,7 @@ type OptionsDir struct {
 	IncludeLength              bool
 	Expanded                   bool
 	NoStatus                   bool
+	FilesOnly                  bool
 }
 
 // NewOptionsDir returns a new initialized OptionsDir


### PR DESCRIPTION
This minor change adds the -xo switch to enable file-only searching. This prevents gobuster from searching directory names first. This is useful when you've already performed a directory search earlier and now want to search for files by extension without re-querying for directories again. This improves speed and removes unnecessary queries.

* Added -xo switch processing
* Added -xo help statement in -h
* Added error handling; -xo can only be set if -x is provided
* Added line to gobuster output:  [+] Files Only   : true

This could be done other ways, but ultimately I chose just making "-xo" since it fits right next to the companion "-x" that everyone is already familiar with. 