### PR TITLE
nuke test dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ go:
   - "1.8"
   - "1.10.x"
   - master
+
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 TARGET=./build
-OSES=darwin linux windows
 ARCHS=amd64 386
 
 current: outputdir
@@ -29,7 +28,6 @@ darwin: outputdir
 		GOOS=darwin GARCH=$${GOARCH} go build -o ${TARGET}/gobuster-darwin-$${GOARCH} ; \
 	done; \
 	echo "Done."
-
 
 all: darwin linux windows
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you have all the dependencies already, you can make use of the build scripts:
 * `make darwin` - builds 32 and 64 bit binaries for darwin, and writes them to the `build` subfolder.
 * `make all` - builds for all platforms and architectures, and writes the resulting binaries to the `build` subfolder.
 * `make clean` - clears out the `build` subfolder.
-* `make test` - runs the tests (requires you to `go get githubcom/h2non/gock` first).
+* `make test` - runs the tests.
 
 #### Running as a script
 ```


### PR DESCRIPTION
This removes the test dependency and uses go core functionality instead