### PR TITLE
trim paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 TARGET=./build
 ARCHS=amd64 386
 LDFLAGS="-s -w"
+GCFLAGS="all=-trimpath=${GOPATH}/src"
+ASMFLAGS="all=-trimpath=${GOPATH}/src"
 
 current: outputdir
 	@go build -o ./gobuster; \
@@ -12,21 +14,21 @@ outputdir:
 windows: outputdir
 	@for GOARCH in ${ARCHS}; do \
 		echo "Building for windows $${GOARCH} ..." ; \
-		GOOS=windows GARCH=$${GOARCH} go build -ldflags=${LDFLAGS} -o ${TARGET}/gobuster-$${GOARCH}.exe ; \
+		GOOS=windows GARCH=$${GOARCH} go build -ldflags=${LDFLAGS} -gcflags=${GCFLAGS} -asmflags=${ASMFLAGS} -o ${TARGET}/gobuster-$${GOARCH}.exe ; \
 	done; \
 	echo "Done."
 
 linux: outputdir
 	@for GOARCH in ${ARCHS}; do \
 		echo "Building for linux $${GOARCH} ..." ; \
-		GOOS=linux GARCH=$${GOARCH} go build -ldflags=${LDFLAGS} -o ${TARGET}/gobuster-linux-$${GOARCH} ; \
+		GOOS=linux GARCH=$${GOARCH} go build -ldflags=${LDFLAGS} -gcflags=${GCFLAGS} -asmflags=${ASMFLAGS} -o ${TARGET}/gobuster-linux-$${GOARCH} ; \
 	done; \
 	echo "Done."
 
 darwin: outputdir
 	@for GOARCH in ${ARCHS}; do \
 		echo "Building for darwin $${GOARCH} ..." ; \
-		GOOS=darwin GARCH=$${GOARCH} go build -ldflags=${LDFLAGS} -o ${TARGET}/gobuster-darwin-$${GOARCH} ; \
+		GOOS=darwin GARCH=$${GOARCH} go build -ldflags=${LDFLAGS} -gcflags=${GCFLAGS} -asmflags=${ASMFLAGS} -o ${TARGET}/gobuster-darwin-$${GOARCH} ; \
 	done; \
 	echo "Done."
 

--- a/make.bat
+++ b/make.bat
@@ -2,7 +2,7 @@
 
 SET ARG=%1
 SET TARGET=.\build
-SET LDFLAGS="-s -w"
+SET BUILDARGS=-ldflags="-s -w" -gcflags="all=-trimpath=%GOPATH%/src" -asmflags="all=-trimpath=%GOPATH%/src"
 
 IF "%ARG%"=="test" (
   go test -v -race ./...
@@ -49,10 +49,10 @@ GOTO Done
 set GOOS=darwin
 set GOARCH=amd64
 echo Building for %GOOS% %GOARCH% ...
-go build -ldflags=%LDFLAGS% -o %TARGET%\gobuster-%GOOS%-%GOARCH%
+go build %BUILDARGS% -o %TARGET%\gobuster-%GOOS%-%GOARCH%
 set GOARCH=386
 echo Building for %GOOS% %GOARCH% ...
-go build -ldflags=%LDFLAGS% -o %TARGET%\gobuster-%GOOS%-%GOARCH%
+go build %BUILDARGS% -o %TARGET%\gobuster-%GOOS%-%GOARCH%
 echo Done.
 EXIT /B 0
 
@@ -60,10 +60,10 @@ EXIT /B 0
 set GOOS=linux
 set GOARCH=amd64
 echo Building for %GOOS% %GOARCH% ...
-go build -ldflags=%LDFLAGS% -o %TARGET%\gobuster-%GOOS%-%GOARCH%
+go build %BUILDARGS% -o %TARGET%\gobuster-%GOOS%-%GOARCH%
 set GOARCH=386
 echo Building for %GOOS% %GOARCH% ...
-go build -ldflags=%LDFLAGS% -o %TARGET%\gobuster-%GOOS%-%GOARCH%
+go build %BUILDARGS% -o %TARGET%\gobuster-%GOOS%-%GOARCH%
 echo Done.
 EXIT /B 0
 
@@ -71,10 +71,10 @@ EXIT /B 0
 set GOOS=windows
 set GOARCH=amd64
 echo Building for %GOOS% %GOARCH% ...
-go build -ldflags=%LDFLAGS% -o %TARGET%\gobuster-%GOARCH%.exe
+go build %BUILDARGS% -o %TARGET%\gobuster-%GOARCH%.exe
 set GOARCH=386
 echo Building for %GOOS% %GOARCH% ...
-go build -ldflags=%LDFLAGS% -o %TARGET%\gobuster-%GOARCH%.exe
+go build %BUILDARGS% -o %TARGET%\gobuster-%GOARCH%.exe
 echo Done.
 EXIT /B 0
 


### PR DESCRIPTION
This removes path info from builds. I was only able to strip GOPATH but not GOROOT as it seems there is only one trimpath parameter supported