### PR TITLE
Force mode check to use lowercase

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func main() {
 	defer cancel()
 
 	var plugin libgobuster.GobusterPlugin
-	switch o.Mode {
+	switch strings.ToLower(o.Mode) {
 	case libgobuster.ModeDir:
 		plugin = gobusterdir.GobusterDir{}
 	case libgobuster.ModeDNS:


### PR DESCRIPTION
The app crashes if you use "DNS" instead of "dns". This is becauase we're using `ToLower` in one part of the code and not in another. This PR fixes this issue in a bit of a hacky way.

Once we're doing with the refactoring of command line options, we're going to rejig the project structure a bit and make sure that options parsing is done properly just in the one spot so that we don't have to litter the code with ToLower to keep things consistent.

Note that this needs to be merged into `v2.0.2-working` (not `master`).