### PR TITLE
Correctly render output in dir mode

### DIFF
--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -99,7 +99,7 @@ func (d GobusterDir) ResultToString(g *libgobuster.Gobuster, r *libgobuster.Resu
 
 	if g.Opts.StatusCodesParsed.Contains(r.Status) || g.Opts.Verbose {
 		if g.Opts.Expanded {
-			if _, err := fmt.Fprintf(buf, g.Opts.URL); err != nil {
+			if _, err := fmt.Fprintf(buf, "%s", g.Opts.URL); err != nil {
 				return nil, err
 			}
 		} else {
@@ -107,7 +107,7 @@ func (d GobusterDir) ResultToString(g *libgobuster.Gobuster, r *libgobuster.Resu
 				return nil, err
 			}
 		}
-		if _, err := fmt.Fprintf(buf, r.Entity); err != nil {
+		if _, err := fmt.Fprintf(buf, "%s", r.Entity); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
When wordlists contain stuff that looks like format strings (such as as `%7ebob`) the output of the results to screen would contain the string `%!e(MISSING)`. This was because the entity was passing the word directly to an Fprintf call as the format string. This PR fixes this so that the output of the word is rendered correctly.

Note that this needs to be merged into `v2.0.2-working` (not `master`).