### PR TITLE
Append results to output file instead of overwriting

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,8 @@ func resultWorker(g *libgobuster.Gobuster, filename string, wg *sync.WaitGroup) 
 	var f *os.File
 	var err error
 	if filename != "" {
-		f, err = os.Create(filename)
+        f, err = os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0660);
+        //	f, err = os.Create(filename)
 		if err != nil {
 			log.Fatalf("error on creating output file: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -48,7 +48,6 @@ func resultWorker(g *libgobuster.Gobuster, filename string, wg *sync.WaitGroup) 
 	var err error
 	if filename != "" {
         f, err = os.OpenFile(filename, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0660);
-        //	f, err = os.Create(filename)
 		if err != nil {
 			log.Fatalf("error on creating output file: %v", err)
 		}


### PR DESCRIPTION
When I'm using the tool to test, I'll often use multiple dictionaries for both DNS and URL path discovery. This allows for the same output file to be used for multiple wordlists against the same target. 