### PR TITLE
Add -h flag to specify HTTP headers

### DIFF
--- a/libgobuster/http.go
+++ b/libgobuster/http.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"unicode/utf8"
+	"errors"
 )
 
 type httpClient struct {
@@ -66,7 +67,7 @@ func newHTTPClient(c context.Context, opt *Options) (*httpClient, error) {
 }
 
 // MakeRequest makes a request to the specified url
-func (client *httpClient) makeRequest(fullURL, cookie string) (*int, *int64, error) {
+func (client *httpClient) makeRequest(fullURL, cookie string, headers headersArray) (*int, *int64, error) {
 	req, err := http.NewRequest(http.MethodGet, fullURL, nil)
 
 	if err != nil {
@@ -78,6 +79,20 @@ func (client *httpClient) makeRequest(fullURL, cookie string) (*int, *int64, err
 
 	if cookie != "" {
 		req.Header.Set("Cookie", cookie)
+	}
+
+	if len(headers) > 0 {
+		for _,r := range headers {
+
+			//parse Header
+			keyAndValue := strings.SplitN(r,":",2)
+			if len(keyAndValue)!=2 {
+				err := errors.New("Error when parsing HttpHeaders")
+				return nil, nil, err
+			}
+
+			req.Header.Set(keyAndValue[0], keyAndValue[1])
+		}
 	}
 
 	ua := fmt.Sprintf("gobuster %s", VERSION)

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -112,7 +112,7 @@ func (g *Gobuster) ClearProgress() {
 // GetRequest issues a GET request to the target and returns
 // the status code, length and an error
 func (g *Gobuster) GetRequest(url string) (*int, *int64, error) {
-	return g.http.makeRequest(url, g.Opts.Cookies)
+	return g.http.makeRequest(url, g.Opts.Cookies, g.Opts.HttpHeaders)
 }
 
 // DNSLookup looks up a domain via system default DNS servers

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -19,6 +19,23 @@ const (
 )
 
 // Options helds all options that can be passed to libgobuster
+
+//This is stub, because golang flag lib can't parse array. This func returns concated headers with \r\n
+type headersArray []string
+
+func (i *headersArray) String() string {
+	all:= ""
+	for _,r:= range *i {
+		all+= r + "\r\n"
+	}
+	return all
+}
+
+func (i *headersArray) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 type Options struct {
 	Extensions        string
 	ExtensionsParsed  stringSet
@@ -46,6 +63,7 @@ type Options struct {
 	WildcardForced    bool
 	Verbose           bool
 	UseSlash          bool
+	HttpHeaders		  headersArray
 }
 
 // NewOptions returns a new initialized Options object

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 	flag.BoolVar(&o.WildcardForced, "fw", false, "Force continued operation when wildcard found")
 	flag.BoolVar(&o.InsecureSSL, "k", false, "Skip SSL certificate verification")
 	flag.BoolVar(&o.NoProgress, "np", false, "Don't display progress")
+	flag.Var(&o.HttpHeaders, "h", "Add custom headers to HTTP Request (example: -h \"Authorization: xxx\" -h \"SOAPAction: action\" ")
 
 	flag.Parse()
 


### PR DESCRIPTION
Flag to specify HTTP headers, i.e:
gobuster -h "Header1: test1" -h "Header2: test2"
