### PR TITLE
Add support for filtering results with a unique size for each status code

### DIFF
--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -117,7 +117,7 @@ func (d GobusterDir) ResultToString(g *libgobuster.Gobuster, r *libgobuster.Resu
 			}
 		}
 
-		if r.Size != nil {
+		if g.Opts.IncludeLength && r.Size != nil {
 			if _, err := fmt.Fprintf(buf, " [Size: %d]", *r.Size); err != nil {
 				return nil, err
 			}

--- a/libgobuster/http.go
+++ b/libgobuster/http.go
@@ -60,7 +60,7 @@ func newHTTPClient(c context.Context, opt *Options) (*httpClient, error) {
 	client.context = c
 	client.username = opt.Username
 	client.password = opt.Password
-	client.includeLength = opt.IncludeLength
+	client.includeLength = opt.IncludeLength || opt.UniqueResponseLength
 	client.userAgent = opt.UserAgent
 	return &client, nil
 }

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -36,6 +36,7 @@ type Options struct {
 	Timeout           time.Duration
 	FollowRedirect    bool
 	IncludeLength     bool
+	UniqueResponseLength     bool
 	NoStatus          bool
 	NoProgress        bool
 	Expanded          bool

--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func main() {
 	flag.BoolVar(&o.Expanded, "e", false, "Expanded mode, print full URLs")
 	flag.BoolVar(&o.NoStatus, "n", false, "Don't print status codes")
 	flag.BoolVar(&o.IncludeLength, "l", false, "Include the length of the body in the output (dir mode only)")
+	flag.BoolVar(&o.UniqueResponseLength, "lu", false, "Only output results with a unique size for each status code")
 	flag.BoolVar(&o.UseSlash, "f", false, "Append a forward-slash to each directory request (dir mode only)")
 	flag.BoolVar(&o.WildcardForced, "fw", false, "Force continued operation when wildcard found")
 	flag.BoolVar(&o.InsecureSSL, "k", false, "Skip SSL certificate verification")


### PR DESCRIPTION
When attempting to brute force web servers, they may return similar responses for different URLs. 

For example, a web server may redirect us to its homepage, giving us the same final result each time for multiple URLs. If we pipeline gobuster's output into other tools, there may be cases where we only care about URLs that point us to unique content.

For example, brute-forcing a web server with the following command:

`./gobuster -m dir -q -k -v -l -w wordlist.txt -u https://example.com`

And wordlist:

```
.
./lib
./bar
./car
../lib
../foo
../../bar
```

Will yield the following:

```
Missed: /../../bar (Status: 400) [Size: 357]
Missed: /../foo (Status: 400) [Size: 357]
Missed: /./car (Status: 404) [Size: 332]
Found: /./lib (Status: 301) [Size: 370]
Missed: /./bar (Status: 404) [Size: 332]
Missed: /../lib (Status: 400) [Size: 357]
Found: /. (Status: 200) [Size: 132]
```

Notice that the paths **../../bar** and **../foo** (likely) result in the same response since they have content of the same size.

There may be cases where I would like to have the following output instead:

```
Found: /./lib (Status: 301) [Size: 370]
Missed: /../foo (Status: 400) [Size: 357]
Missed: /./car (Status: 404) [Size: 332]
Found: /. (Status: 200) [Size: 132]
```

Since I only care about URLs that will give me a unique response.

I have implemented a patch that allows gobuster to filter results with a unique size for each status code to addresses the issue above.


If there is anything I have missed, I will be happy to address it in subsequent commits.