### PR TITLE
Add option to use HEAD requests

### DIFF
--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -169,6 +169,11 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 		return nil, nil, fmt.Errorf("invalid value for addslash: %v", err)
 	}
 
+	plugin.HeadRequests, err = cmdDir.Flags().GetBool("head")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for head: %v", err)
+	}
+
 	// Prompt for PW if not provided
 	if plugin.Username != "" && plugin.Password == "" {
 		fmt.Printf("[?] Auth Password: ")
@@ -212,6 +217,7 @@ func init() {
 	cmdDir.Flags().BoolP("insecuressl", "k", false, "Skip SSL certificate verification")
 	cmdDir.Flags().BoolP("addslash", "f", false, "Apped / to each request")
 	cmdDir.Flags().BoolP("wildcard", "", false, "Force continued operation when wildcard found")
+	cmdDir.Flags().BoolP("head", "H", false, "Use HEAD requests if possible")
 
 	if err := cmdDir.MarkFlagRequired("url"); err != nil {
 		log.Fatalf("error on marking flag as required: %v", err)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -70,11 +70,6 @@ func parseGlobalOptions() (*libgobuster.Options, error) {
 		return nil, fmt.Errorf("invalid value for noprogress: %v", err)
 	}
 
-	globalopts.HeadRequests, err = rootCmd.Flags().GetBool("headrequests")
-	if err != nil {
-		return nil, fmt.Errorf("invalid value for headrequests: %v", err)
-	}
-
 	return globalopts, nil
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -70,6 +70,11 @@ func parseGlobalOptions() (*libgobuster.Options, error) {
 		return nil, fmt.Errorf("invalid value for noprogress: %v", err)
 	}
 
+	globalopts.HeadRequests, err = rootCmd.Flags().GetBool("headrequests")
+	if err != nil {
+		return nil, fmt.Errorf("invalid value for headrequests: %v", err)
+	}
+
 	return globalopts, nil
 }
 

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -23,7 +23,7 @@ type GobusterDir struct {
 // GetRequest issues a GET request to the target and returns
 // the status code, length and an error
 func (d *GobusterDir) get(url string) (*int, *int64, error) {
-	return d.http.makeRequest(url, d.options.Cookies)
+	return d.http.makeRequest(url, d.options.Cookies, d.options)
 }
 
 // NewGobusterDir creates a new initialized GobusterDir

--- a/gobusterdir/http.go
+++ b/gobusterdir/http.go
@@ -69,7 +69,12 @@ func newHTTPClient(c context.Context, opt *OptionsDir) (*httpClient, error) {
 
 // MakeRequest makes a request to the specified url
 func (client *httpClient) makeRequest(fullURL, cookie string) (*int, *int64, error) {
-	req, err := http.NewRequest(http.MethodGet, fullURL, nil)
+	// attempt a HEAD request if specified by the user 
+	if opt.HeadRequests {
+		req, err := http.NewRequest(http.MethodHead, fullURL, nil)
+	} else {
+		req, err := http.NewRequest(http.MethodGet, fullURL, nil)
+	}
 
 	if err != nil {
 		return nil, nil, err
@@ -101,6 +106,11 @@ func (client *httpClient) makeRequest(fullURL, cookie string) (*int, *int64, err
 			}
 		}
 		return nil, nil, err
+	}
+
+	// disable HEAD requests if the target does not support the method
+	if opt.HeadRequests && (resp.StatusCode == 405 || resp.StatusCode == 501) {
+		opt.HeadRequests = false
 	}
 
 	defer resp.Body.Close()

--- a/gobusterdir/http.go
+++ b/gobusterdir/http.go
@@ -69,11 +69,11 @@ func newHTTPClient(c context.Context, opt *OptionsDir) (*httpClient, error) {
 
 // MakeRequest makes a request to the specified url
 func (client *httpClient) makeRequest(fullURL, cookie string, opt *OptionsDir) (*int, *int64, error) {
+	req, err := http.NewRequest(http.MethodGet, fullURL, nil)
+
 	// attempt a HEAD request if specified by the user 
 	if opt.HeadRequests {
-		req, err := http.NewRequest(http.MethodHead, fullURL, nil)
-	} else {
-		req, err := http.NewRequest(http.MethodGet, fullURL, nil)
+		req, err = http.NewRequest(http.MethodHead, fullURL, nil)
 	}
 
 	if err != nil {

--- a/gobusterdir/http.go
+++ b/gobusterdir/http.go
@@ -68,7 +68,7 @@ func newHTTPClient(c context.Context, opt *OptionsDir) (*httpClient, error) {
 }
 
 // MakeRequest makes a request to the specified url
-func (client *httpClient) makeRequest(fullURL, cookie string) (*int, *int64, error) {
+func (client *httpClient) makeRequest(fullURL, cookie string, opt *OptionsDir) (*int, *int64, error) {
 	// attempt a HEAD request if specified by the user 
 	if opt.HeadRequests {
 		req, err := http.NewRequest(http.MethodHead, fullURL, nil)

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -27,6 +27,7 @@ type OptionsDir struct {
 	UseSlash          bool
 	IsWildcard        bool
 	WildcardForced    bool
+	HeadRequests      bool
 }
 
 // NewOptionsDir returns a new initialized OptionsDir

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -1,10 +1,11 @@
 package libgobuster
 
-// Options helds all options that can be passed to libgobuster
+// Options holds all options that can be passed to libgobuster
 type Options struct {
 	Threads        int
 	Wordlist       string
 	OutputFilename string
+	HeadRequests   bool
 	NoStatus       bool
 	NoProgress     bool
 	Quiet          bool

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -5,7 +5,6 @@ type Options struct {
 	Threads        int
 	Wordlist       string
 	OutputFilename string
-	HeadRequests   bool
 	NoStatus       bool
 	NoProgress     bool
 	Quiet          bool


### PR DESCRIPTION
The intent of this patch is to improve speed by utilizing the HEAD method of HTTP. The current default/only option for gobuster is to make GET requests to the target service. This incurs a fair amount of overhead as gobuster will receive the full contents of the URI in addition to the HTTP response headers. By using HEAD, only the response headers will be returned, from which the HTTP code and Content-Length can be parsed. In the event that the HEAD method is not supported by the target, a `405 Method Not Allowed` or `501 Not Implemented` response will disable the use of HEAD requests and revert to the original behavior of GET requests.

Notably @0xdevalias requests this feature and @mzpqnxow warns against this approach in [#53](https://github.com/OJ/gobuster/issues/53). Accordingly we only opt for HEAD requests when specified by the user via the `-H` or `--head` command line option added with this diff.