### PR TITLE
Update Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ All funds that are donated to this project will be donated to charity. A full lo
 Since this tool is written in [Go](https://golang.org/) you need install the Go language/compiler/etc. Full details of installation and set up can be found [on the Go language website](https://golang.org/doc/install). Once installed you have two options.
 
 #### Compiling
+
 `gobuster` now has external dependencies, and so they need to be pulled in first:
 ```
 gobuster $ go get && go build


### PR DESCRIPTION
Easy gobuster installation:
--

``
$ go get github.com/OJ/gobuster
``

Now search the abs path:

```
find / -name gobuster -print 
...
/root/go/bin/gobuster
```

At this point create a link:

``
ln /root/go/bin/gobuster /bin/gobuster OR ln /root/go/bin/gobuster /usr/bin/gobuster
``

```
$ gobuster -h

Usage of gobuster:
  -P string
        Password for Basic Auth (dir mode only)
  -U string
        Username
....
```