### PR TITLE
Bust using placeholder strings.

### DIFF
--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -129,6 +129,15 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 		return nil, nil, fmt.Errorf("invalid value for proxy: %v", err)
 	}
 
+	plugin.StringReplace, err = cmdDir.Flags().GetString("stringreplace")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for stringreplace: %v", err)
+	}
+
+	if plugin.StringReplace != "" && !strings.Contains(plugin.URL, plugin.StringReplace) {
+		return nil, nil, fmt.Errorf("stringreplace token '%s' not found in url", plugin.StringReplace)
+	}
+
 	plugin.Timeout, err = cmdDir.Flags().GetDuration("timeout")
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid value for timeout: %v", err)
@@ -204,6 +213,7 @@ func init() {
 	cmdDir.Flags().StringP("extensions", "x", "", "File extension(s) to search for")
 	cmdDir.Flags().StringP("useragent", "a", libgobuster.DefaultUserAgent(), "Set the User-Agent string")
 	cmdDir.Flags().StringP("proxy", "p", "", "Proxy to use for requests [http(s)://host:port]")
+	cmdDir.Flags().StringP("stringreplace", "S", "", "A placeholder value to perform string replacements on")
 	cmdDir.Flags().DurationP("timeout", "", 10*time.Second, "HTTP Timeout")
 	cmdDir.Flags().BoolP("followredirect", "r", false, "Follow redirects")
 	cmdDir.Flags().BoolP("expanded", "e", false, "Expanded mode, print full URLs")

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -17,6 +17,7 @@ type OptionsDir struct {
 	UserAgent         string
 	Username          string
 	Proxy             string
+	StringReplace     string
 	Cookies           string
 	Timeout           time.Duration
 	FollowRedirect    bool


### PR DESCRIPTION
# proposal

Reimplementation of #71.

Add the ability to use a placeholder value to replace parts of a URL using a wordlist. The same placeholder string may be used in multiple locations, ultimately allowing for complex busting.

Example replacements:

```text
http://127.0.0.1/zFOOa -> http://127.0.0.1/zword1a
http://127.0.0.1/zFOOa -> http://127.0.0.1/zword2a
http://127.0.0.1/zFOOa/FOO -> http://127.0.0.1/zword2a/word2
http://127.0.0.1/FOO.txt -> http://127.0.0.1/word3.txt
```

# sample usage

```bash
$ go run main.go -q dir --url http://127.0.0.1:58863/aFOOzFOO -w common.txt -t 1 -S FOO
/netcat (string replacement requested as: http://127.0.0.1:58863/anetcatznetcat) (Status: 301)
/zip (string replacement requested as: http://127.0.0.1:58863/azipzzip) (Status: 200)
```

Regardless if the problems mentioned below, I believe this to be a useful feature nonetheless.

# problems

1. A trailing slash gets appended in `GobusterDir.PreRun()` and causes misses on some web servers where the target URI is a file (not a dir). I know this is added in the `dir` subcommand, but I added a strip for this slash and only add the slash when `-f` is specified again. However, this causes an inverse effect when the original URL actually has a `/` and `-f` is not specified. I suspect this may need some different handling overall. I am also happy to remove that and keep the intended `dir` context of the subcommand.

2. Output by default is not very useful given the nature when a replace method is used. I added a more verbose blurp as I am not sure if editing the original URL is really a good idea. That being said, `-v` and `-e` seem equally odd when it comes to output because of this.