### PR TITLE
Add flag -H to specify HTTP Headers

### DIFF
--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -21,6 +21,7 @@ import (
 
 var cmdDir *cobra.Command
 
+
 func runDir(cmd *cobra.Command, args []string) error {
 	globalopts, pluginopts, err := parseDirOptions()
 	if err != nil {
@@ -169,6 +170,11 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 		return nil, nil, fmt.Errorf("invalid value for addslash: %v", err)
 	}
 
+	plugin.Headers, err = cmdDir.Flags().GetStringArray("headers")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for headers: %v", err)
+	}
+
 	// Prompt for PW if not provided
 	if plugin.Username != "" && plugin.Password == "" {
 		fmt.Printf("[?] Auth Password: ")
@@ -212,6 +218,7 @@ func init() {
 	cmdDir.Flags().BoolP("insecuressl", "k", false, "Skip SSL certificate verification")
 	cmdDir.Flags().BoolP("addslash", "f", false, "Apped / to each request")
 	cmdDir.Flags().BoolP("wildcard", "", false, "Force continued operation when wildcard found")
+	cmdDir.Flags().StringArrayP("headers","H",[]string{""},"Specify HTTP headers, -H 'Header1: val1' -H 'Header2: val2'")
 
 	if err := cmdDir.MarkFlagRequired("url"); err != nil {
 		log.Fatalf("error on marking flag as required: %v", err)

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -23,7 +23,7 @@ type GobusterDir struct {
 // GetRequest issues a GET request to the target and returns
 // the status code, length and an error
 func (d *GobusterDir) get(url string) (*int, *int64, error) {
-	return d.http.makeRequest(url, d.options.Cookies)
+	return d.http.makeRequest(url, d.options.Cookies, d.options.Headers)
 }
 
 // NewGobusterDir creates a new initialized GobusterDir

--- a/gobusterdir/http.go
+++ b/gobusterdir/http.go
@@ -68,7 +68,7 @@ func newHTTPClient(c context.Context, opt *OptionsDir) (*httpClient, error) {
 }
 
 // MakeRequest makes a request to the specified url
-func (client *httpClient) makeRequest(fullURL, cookie string) (*int, *int64, error) {
+func (client *httpClient) makeRequest(fullURL, cookie string, headers []string) (*int, *int64, error) {
 	req, err := http.NewRequest(http.MethodGet, fullURL, nil)
 
 	if err != nil {
@@ -87,6 +87,28 @@ func (client *httpClient) makeRequest(fullURL, cookie string) (*int, *int64, err
 		ua = client.userAgent
 	}
 	req.Header.Set("User-Agent", ua)
+
+	if len(headers) > 0 {
+		for _,r := range headers {
+
+			//parse Header
+			keyAndValue := strings.SplitN(r,":",2)
+			if len(keyAndValue)!=2 { //Check if we have both elements, header name and header value
+				return nil, nil, fmt.Errorf("Error when parsing HTTP Headers: %v", r)
+			}
+
+			if len(keyAndValue[0])==0{ //Check that the header name is not empty, btw header value empty is ok
+				return nil, nil, fmt.Errorf("Error when parsing HTTP Headers, header name is empty %v", r)
+			}
+
+			//req.Header.Set(keyAndValue[0], keyAndValue[1])
+			//This is because Header.Set is case insensitive, and it always converts case by default, hEAdEr -> Header
+			//So, I think this Idea is better:
+			req.Header[keyAndValue[0]] = []string{keyAndValue[1]}
+
+
+		}
+	}
 
 	if client.username != "" {
 		req.SetBasicAuth(client.username, client.password)

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -27,6 +27,7 @@ type OptionsDir struct {
 	UseSlash          bool
 	IsWildcard        bool
 	WildcardForced    bool
+	Headers			  []string
 }
 
 // NewOptionsDir returns a new initialized OptionsDir


### PR DESCRIPTION
Flag -H to specify HTTP Headers by array:
gobuster dir -H "Test: 12323" -H "Test2: xxxx:xasdd:" -H "test:123"
This makes next headers:
```
Test: 12323
Test2: xxxx:xasdd:
test: 123

```