### PR TITLE
Change some I/O messages channels

### DIFF
--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -3,7 +3,6 @@ package gobusterdir
 import (
 	"bytes"
 	"fmt"
-	"log"
 
 	"github.com/OJ/gobuster/libgobuster"
 	"github.com/google/uuid"
@@ -29,7 +28,7 @@ func (d GobusterDir) Setup(g *libgobuster.Gobuster) error {
 
 	if g.Opts.StatusCodesParsed.Contains(*wildcardResp) {
 		g.IsWildcard = true
-		log.Printf("[-] Wildcard response found: %s => %d", url, *wildcardResp)
+		fmt.Printf("[-] Wildcard response found: %s => %d\n", url, *wildcardResp)
 		if !g.Opts.WildcardForced {
 			return fmt.Errorf("To force processing of Wildcard responses, specify the '-fw' switch.")
 		}

--- a/main.go
+++ b/main.go
@@ -102,6 +102,11 @@ func writeToFile(f *os.File, output string) error {
 	return nil
 }
 
+// Timestamp for message logging to STDOUT
+func msgTimeStamp(msg string) {
+	fmt.Printf("%s %s\n", time.Now().Format("2006-01-02 15:04:05"), msg)
+}
+
 func main() {
 	var outputFilename string
 	o := libgobuster.NewOptions()
@@ -173,7 +178,7 @@ func main() {
 		}
 		fmt.Println(c)
 		ruler()
-		log.Println("Starting gobuster")
+		msgTimeStamp("Starting gobuster")
 		ruler()
 	}
 
@@ -210,7 +215,7 @@ func main() {
 	if !o.Quiet {
 		gobuster.ClearProgress()
 		ruler()
-		log.Println("Finished")
+		msgTimeStamp("Finished - " + o.URL)
 		ruler()
 	}
 }


### PR DESCRIPTION
Changes referenced in [#142](https://github.com/OJ/gobuster/pull/142) were not applied.

Some of the default I/O STDERR messages made it difficult to thread multiple background executions of the tool. With the I/O adjustments, it is very easy to monitor the state of multiple requests.

```
$ ~/gobuster -t 30 -e -w /usr/share/dirbuster/wordlists/directory-list-lowercase-2.3-medium.txt -np -k -u https://10.10.10.10 2>/dev/null &

=====================================================
Gobuster v2.0.1              OJ Reeves (@TheColonial)
=====================================================
[+] Mode         : dir
[+] Url/Domain   : https://10.10.10.10/
[+] Threads      : 30
[+] Wordlist     : /usr/share/dirbuster/wordlists/directory-list-lowercase-2.3-medium.txt
[+] Status codes : 200,204,301,302,307,403
[+] Expanded     : true
[+] Timeout      : 10s
=====================================================
2019-05-16 09:03:42 Starting gobuster
=====================================================
[-] Wildcard response found: https://10.10.10.10/244d3fa3-f73c-4c47-8aba-349680b4ae5d => 302
=====================================================
2019-05-16 09:03:43 Finished - https://10.10.10.10/
=====================================================
```