### PR TITLE
V3.0 working - Updates

### DIFF
--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -25,7 +25,9 @@ func runDir(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := cli.Gobuster(mainContext, globalopts, plugin); err != nil {
-		if err == gobusterdir.ErrWildcard {
+		if plugin.WildCard.ErrorCheck(err) {
+			url, code := plugin.WildCard.GetDir()
+			fmt.Printf("[*] Wildcard Detected: %s => %v\n", url, code)
 			return fmt.Errorf("the server returns the same status code for every request. To force processing of Wildcard responses, specify the '--wildcard' switch")
 		}
 		return fmt.Errorf("error on running goubster: %v", err)

--- a/cli/cmd/dns.go
+++ b/cli/cmd/dns.go
@@ -26,7 +26,9 @@ func runDNS(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := cli.Gobuster(mainContext, globalopts, plugin); err != nil {
-		if err == gobusterdns.ErrWildcard {
+		if plugin.WildCard.ErrorCheck(err) {
+			domain, ip := plugin.WildCard.GetDNS()
+			fmt.Printf("[*] Wildcard Detected: %s => %v\n", domain, ip)
 			return fmt.Errorf("the DNS Server returned to same IP for every domain. To force processing of Wildcard DNS, specify the '--wildcard' switch")
 		}
 		return fmt.Errorf("error on running goubster: %v", err)

--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/OJ/gobuster/v3/helper"
 	"github.com/OJ/gobuster/v3/libgobuster"
 )
 
@@ -123,7 +122,7 @@ func Gobuster(prevCtx context.Context, opts *libgobuster.Options, plugin libgobu
 		}
 		fmt.Println(c)
 		ruler()
-		helper.MsgTimeStamp("Starting gobuster")
+		libgobuster.MsgTimeStamp("Starting gobuster")
 		ruler()
 	}
 
@@ -158,7 +157,7 @@ func Gobuster(prevCtx context.Context, opts *libgobuster.Options, plugin libgobu
 	if !opts.Quiet {
 		gobuster.ClearProgress()
 		ruler()
-		helper.MsgTimeStamp("Finished - " + plugin.GetRequestString())
+		libgobuster.MsgTimeStamp("Finished - " + plugin.GetRequestString())
 		ruler()
 	}
 	return nil

--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/OJ/gobuster/v3/helper"
 	"github.com/OJ/gobuster/v3/libgobuster"
 )
 
@@ -122,7 +123,7 @@ func Gobuster(prevCtx context.Context, opts *libgobuster.Options, plugin libgobu
 		}
 		fmt.Println(c)
 		ruler()
-		log.Println("Starting gobuster")
+		helper.MsgTimeStamp("Starting gobuster")
 		ruler()
 	}
 
@@ -157,7 +158,7 @@ func Gobuster(prevCtx context.Context, opts *libgobuster.Options, plugin libgobu
 	if !opts.Quiet {
 		gobuster.ClearProgress()
 		ruler()
-		log.Println("Finished")
+		helper.MsgTimeStamp("Finished")
 		ruler()
 	}
 	return nil

--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -158,7 +158,7 @@ func Gobuster(prevCtx context.Context, opts *libgobuster.Options, plugin libgobu
 	if !opts.Quiet {
 		gobuster.ClearProgress()
 		ruler()
-		helper.MsgTimeStamp("Finished")
+		helper.MsgTimeStamp("Finished - " + plugin.GetRequestString())
 		ruler()
 	}
 	return nil

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"text/tabwriter"
@@ -13,14 +12,12 @@ import (
 	"github.com/google/uuid"
 )
 
-// ErrWildcard is returned if a wildcard response is found
-var ErrWildcard = errors.New("wildcard found")
-
 // GobusterDir is the main type to implement the interface
 type GobusterDir struct {
 	options    *OptionsDir
 	globalopts *libgobuster.Options
 	http       *libgobuster.HTTPClient
+	WildCard   *libgobuster.WildCard
 }
 
 // GetRequest issues a GET request to the target and returns
@@ -42,6 +39,7 @@ func NewGobusterDir(cont context.Context, globalopts *libgobuster.Options, opts 
 	g := GobusterDir{
 		options:    opts,
 		globalopts: globalopts,
+		WildCard:   libgobuster.WildCardInit(),
 	}
 
 	httpOpts := libgobuster.HTTPOptions{
@@ -83,7 +81,8 @@ func (d *GobusterDir) PreRun() error {
 	}
 
 	if d.options.StatusCodesParsed.Contains(*wildcardResp) && !d.options.WildcardForced {
-		return ErrWildcard
+		d.WildCard.Set(d.options.URL, *wildcardResp, "")
+		return fmt.Errorf("wildcard found")
 	}
 
 	return nil

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -305,3 +305,9 @@ func (d *GobusterDir) GetConfigString() (string, error) {
 
 	return strings.TrimSpace(buffer.String()), nil
 }
+
+// GetRequestString returns the string representation of the current request
+func (d *GobusterDir) GetRequestString() string {
+	o := d.options
+	return o.URL
+}

--- a/gobusterdns/gobusterdns.go
+++ b/gobusterdns/gobusterdns.go
@@ -232,3 +232,9 @@ func (d *GobusterDNS) dnsLookupCname(domain string) (string, error) {
 	time.Sleep(time.Second)
 	return d.resolver.LookupCNAME(ctx, domain)
 }
+
+// GetRequestString returns the string representation of the current request
+func (d *GobusterDNS) GetRequestString() string {
+	o := d.options
+	return o.Domain
+}

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -199,3 +199,9 @@ func (v *GobusterVhost) GetConfigString() (string, error) {
 
 	return strings.TrimSpace(buffer.String()), nil
 }
+
+// GetRequestString returns the string representation of the current request
+func (v *GobusterVhost) GetRequestString() string {
+	o := v.options
+	return o.URL
+}

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/OJ/gobuster/v3/libgobuster"
 )
@@ -41,9 +40,4 @@ func ParseStatusCodes(statuscodes string) (libgobuster.IntSet, error) {
 		ret.Add(i)
 	}
 	return ret, nil
-}
-
-// TimeStamped STDOUT Messages
-func MsgTimeStamp(msg string) {
-	fmt.Printf("%s %s\n", time.Now().Format("2006-01-02 15:04:05"), msg)
 }

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/OJ/gobuster/v3/libgobuster"
 )
@@ -40,4 +41,9 @@ func ParseStatusCodes(statuscodes string) (libgobuster.IntSet, error) {
 		ret.Add(i)
 	}
 	return ret, nil
+}
+
+// TimeStamped STDOUT Messages
+func MsgTimeStamp(msg string) {
+	fmt.Printf("%s %s\n", time.Now().Format("2006-01-02 15:04:05"), msg)
 }

--- a/libgobuster/helpers.go
+++ b/libgobuster/helpers.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 )
 
 // IntSet is a set of Ints
@@ -124,4 +125,9 @@ func lineCounter(r io.Reader) (int, error) {
 // DefaultUserAgent returns the default user agent to use in HTTP requests
 func DefaultUserAgent() string {
 	return fmt.Sprintf("gobuster/%s", VERSION)
+}
+
+// TimeStamped STDOUT Messages
+func MsgTimeStamp(msg string) {
+	fmt.Printf("%s %s\n", time.Now().Format("2006-01-02 15:04:05"), msg)
 }

--- a/libgobuster/helpers.go
+++ b/libgobuster/helpers.go
@@ -2,12 +2,21 @@ package libgobuster
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
 	"time"
 )
+
+// WildCard is a interface for error reporting
+type WildCard struct {
+	error   error
+	request string
+	code    int
+	ip      string
+}
 
 // IntSet is a set of Ints
 type IntSet struct {
@@ -66,6 +75,33 @@ func (set *StringSet) Stringify() string {
 		values = append(values, s)
 	}
 	return strings.Join(values, ",")
+}
+
+// WildCardInit creates a new WildCard reference
+func WildCardInit() *WildCard {
+	return &WildCard{error: errors.New("wildcard found")}
+}
+
+// ErrorCheck validates if error matches wildcard
+func (w *WildCard) ErrorCheck(e error) bool {
+	return e.Error() == w.error.Error()
+}
+
+// Set sets the requested URL and code in the set
+func (w *WildCard) Set(r string, c int, ip string) {
+	w.request = r
+	w.code = c
+	w.ip = ip
+}
+
+// GetDir returns the URL and code in the set
+func (w *WildCard) GetDir() (string, int) {
+	return w.request, w.code
+}
+
+// GetDNS returns the Domain and IP in the set
+func (w *WildCard) GetDNS() (string, string) {
+	return w.request, w.ip
 }
 
 // NewIntSet creates a new initialized IntSet

--- a/libgobuster/interfaces.go
+++ b/libgobuster/interfaces.go
@@ -6,4 +6,5 @@ type GobusterPlugin interface {
 	Run(string) ([]Result, error)
 	ResultToString(*Result) (*string, error)
 	GetConfigString() (string, error)
+	GetRequestString() string
 }

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -182,3 +182,8 @@ Scan:
 func (g *Gobuster) GetConfigString() (string, error) {
 	return g.plugin.GetConfigString()
 }
+
+// GetRequestString returns the current request as a printable string
+func (g *Gobuster) GetRequestString() string {
+	return g.plugin.GetRequestString()
+}


### PR DESCRIPTION
Some of the default I/O STDERR messages made it difficult to thread multiple background executions of the tool. With the I/O adjustments, it is very easy to monitor the state of multiple requests.

```
$ ./gobuster dir -w /opt/lists/directory-list-lowercase-2.3-medium.txt -e -z -t 5 -k -u http://10.10.10.10/ 2>/dev/null
===============================================================
Gobuster v3.0.0 (beta)
by OJ Reeves (@TheColonial) & Christian Mehlmauer (@_FireFart_)
===============================================================
[+] Url:            http://10.10.10.10/
[+] Threads:        5
[+] Wordlist:       /opt/lists/directory-list-lowercase-2.3-medium.txt
[+] Status codes:   200,204,301,302,307,401,403
[+] User Agent:     gobuster/3.0.0 (beta)
[+] Expanded:       true
[+] Timeout:        10s
===============================================================
2019-05-24 09:30:42 Starting gobuster
===============================================================
[*] Wildcard Detected: http://10.10.10.10/ => 302
```