### PR TITLE
Fixed gobuster spelling error

### DIFF
--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -28,7 +28,7 @@ func runDir(cmd *cobra.Command, args []string) error {
 		if goberr, ok := err.(*gobusterdir.ErrWildcard); ok {
 			return fmt.Errorf("%s. To force processing of Wildcard responses, specify the '--wildcard' switch", goberr.Error())
 		}
-		return fmt.Errorf("error on running goubster: %v", err)
+		return fmt.Errorf("error on running gobuster: %v", err)
 	}
 	return nil
 }

--- a/cli/cmd/dir_test.go
+++ b/cli/cmd/dir_test.go
@@ -85,7 +85,7 @@ func BenchmarkDirMode(b *testing.B) {
 		}
 
 		if err := cli.Gobuster(ctx, &globalopts, plugin); err != nil {
-			b.Fatalf("error on running goubster: %v", err)
+			b.Fatalf("error on running gobuster: %v", err)
 		}
 		os.Stdout = oldStdout
 		os.Stderr = oldStderr

--- a/cli/cmd/dns.go
+++ b/cli/cmd/dns.go
@@ -29,7 +29,7 @@ func runDNS(cmd *cobra.Command, args []string) error {
 		if goberr, ok := err.(*gobusterdns.ErrWildcard); ok {
 			return fmt.Errorf("%s. To force processing of Wildcard DNS, specify the '--wildcard' switch", goberr.Error())
 		}
-		return fmt.Errorf("error on running goubster: %v", err)
+		return fmt.Errorf("error on running gobuster: %v", err)
 	}
 	return nil
 }

--- a/cli/cmd/vhost.go
+++ b/cli/cmd/vhost.go
@@ -24,7 +24,7 @@ func runVhost(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := cli.Gobuster(mainContext, globalopts, plugin); err != nil {
-		return fmt.Errorf("error on running goubster: %v", err)
+		return fmt.Errorf("error on running gobuster: %v", err)
 	}
 	return nil
 }

--- a/cli/cmd/vhost_test.go
+++ b/cli/cmd/vhost_test.go
@@ -60,7 +60,7 @@ func BenchmarkVhostMode(b *testing.B) {
 		}
 
 		if err := cli.Gobuster(ctx, &globalopts, plugin); err != nil {
-			b.Fatalf("error on running goubster: %v", err)
+			b.Fatalf("error on running gobuster: %v", err)
 		}
 		os.Stdout = oldStdout
 		os.Stderr = oldStderr


### PR DESCRIPTION
After running into an error, I noticed that "Gobuster" was misspelled. After running a quick recursive grep I found that this mistake was repeated quite a few times. This is a small patch to fix those misspellings.