### PR TITLE
DNS Bruteforce Injection Point Definition

### DIFF
--- a/gobusterdns/gobusterdns.go
+++ b/gobusterdns/gobusterdns.go
@@ -92,7 +92,7 @@ func (d *GobusterDNS) PreRun() error {
 			if err != nil {
 				// Not an error, just a warning. Eg. `yp.to` doesn't resolve, but `cr.yp.to` does!
 				log.Printf("[-] Unable to validate base domain: %s (%v)", d.options.Domain, err)
-			} 
+			}
 		} else {
 			// Warning: Injection char (*) was provided, no base domain validation will be performed!
 			log.Printf("[-] Warning: Injection char (*) was provided, no base domain validation will be performed!")
@@ -106,9 +106,9 @@ func (d *GobusterDNS) PreRun() error {
 func (d *GobusterDNS) Run(word string) ([]libgobuster.Result, error) {
 	subdomain := ""
 	if strings.Contains(d.options.Domain, "*") == true {
-		subdomain = strings.Replace(d.options.Domain, "*", word, -1) // Path?
+		subdomain = strings.Replace(d.options.Domain, "*", word, -1)
 	} else {
-		subdomain = fmt.Sprintf("%s.%s", word, d.options.Domain)	
+		subdomain = fmt.Sprintf("%s.%s", word, d.options.Domain)
 	}
 	ips, err := d.dnsLookup(subdomain)
 	var ret []libgobuster.Result


### PR DESCRIPTION
Adding Injection Point indicator in DNS Bruteforce Process in order to expand the subdomain enumeration capabilities.

The modified code can be triaged using the following execution line:

`go run main.go dns -t 50 -d *-app.abumedia.yql.yahoo.com -w wordlist.txt`

Result:
```
===============================================================
Gobuster v3.0.1
by OJ Reeves (@TheColonial) & Christian Mehlmauer (@_FireFart_)
===============================================================
[+] Domain:     *-app.abumedia.yql.yahoo.com
[+] Threads:    50
[+] Timeout:    1s
[+] Wordlist:   /Users/hdbreaker/Desktop/Scripts/DirBuster/directory-list-lowercase-2.3-medium.txt
===============================================================
2019/07/27 15:19:58 Starting gobuster
===============================================================
2019/07/27 15:19:58 [-] Warning: Injection char (*) was provided, no base domain validation will be performed!
Found: news-app.abumedia.yql.yahoo.com
Found: tv-app.abumedia.yql.yahoo.com
===============================================================
2019/07/27 15:20:06 Finished
===============================================================
```

If the * character is not provided Gobuster will work as before.
