### PR TITLE
Add Permutations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   disable:
     - lll
     - gocyclo
+    - dupl
 
 issues:
   exclude-rules:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ All funds that are donated to this project will be donated to charity. A full lo
 
 * enumerate public AWS S3 buckets
 * specify HTTP method
+* added support for permutations. You can now specify a file containing permutations that are applied to every word, one by line. Every occurence of the term `{GOBUSTER}` in it will be replaced with the current wordlist item. Please use with caution as this can cause increase the number of requests issued a lot.
+* The shorthand `p` flag which was assigned to proxy is now used by the permutations
 
 ## Changes in 3.0
 
@@ -56,6 +58,7 @@ All funds that are donated to this project will be donated to charity. A full lo
 
 * dir - the classic directory brute-forcing mode
 * dns - DNS subdomain brute-forcing mode
+* s3 - Enumerate open S3 buckets and look for existence and bucket listings
 * vhost - virtual host brute-forcing mode (not the same as DNS!)
 
 ## Built-in Help
@@ -209,6 +212,24 @@ hashcat -a 3 --stdout ?l | gobuster dir -u https://mysite.com -w -
 ```
 
 Note: If the `-w` option is specified at the same time as piping from STDIN, an error will be shown and the program will terminate.
+
+## Permuations
+
+You can supply permutation files that will be applied to every word from the wordlist.
+Just place the string `{GOBUSTER}` in it and this will be replaced with the word.
+This feature is also handy in s3 mode to pre- or postfix certain patterns.
+
+**Caution:** Using a big permutation file can cause a lot of request as every permutation is applied to every word in the wordlist.
+
+### Example file
+
+```text
+{GOBUSTER}Partial
+{GOBUSTER}Service
+PRE{GOBUSTER}POST
+{GOBUSTER}-prod
+{GOBUSTER}-dev
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# Gobuster v3.0.1 (OJ Reeves @TheColonial)
+# Gobuster v3.1.0
 
 Gobuster is a tool used to brute-force:
 
 * URIs (directories and files) in web sites.
 * DNS subdomains (with wildcard support).
 * Virtual Host names on target web servers.
+* Open Amazon S3 buckets
 
 ## Tags, Statuses, etc
 
@@ -39,11 +40,15 @@ If you're backing us already, you rock. If you're not, that's cool too! Want to 
 
 All funds that are donated to this project will be donated to charity. A full log of charity donations will be available in this repository as they are processed.
 
+## Changes in 3.1
+
+* enumerate public AWS S3 buckets
+
 ## Changes in 3.0
 
 * New CLI options so modes are strictly seperated (`-m` is now gone!)
 * Performance Optimizations and better connection handling
-* Ability to bruteforce vhost names
+* Ability to enumerate vhost names
 * Option to supply custom HTTP headers
 
 ## Available Modes
@@ -527,6 +532,103 @@ Found: piwik.mysite.com
 Found: mail.mysite.com
 ===============================================================
 2019/06/21 08:36:05 Finished
+===============================================================
+```
+
+### `s3` Mode
+
+Command line might look like this:
+
+```bash
+gobuster s3 -w bucket-names.txt
+```
+
+Normal sample run goes like this:
+
+```text
+PS C:\Users\firefart\Documents\code\gobuster> .\gobuster.exe s3 --wordlist .\wordlist.txt
+===============================================================
+Gobuster v3.1.0
+by OJ Reeves (@TheColonial) & Christian Mehlmauer (@_FireFart_)
+===============================================================
+[+] Threads:                 10
+[+] Wordlist:                .\wordlist.txt
+[+] User Agent:              gobuster/3.1.0
+[+] Timeout:                 10s
+[+] Maximum files to list:   5
+===============================================================
+2019/08/12 21:48:16 Starting gobuster in S3 bucket enumeration mode
+===============================================================
+webmail
+hacking
+css
+img
+www
+dav
+web
+localhost
+===============================================================
+2019/08/12 21:48:17 Finished
+===============================================================
+```
+
+Verbose and sample run
+
+```text
+PS C:\Users\firefart\Documents\code\gobuster> .\gobuster.exe s3 --wordlist .\wordlist.txt -v
+===============================================================
+Gobuster v3.1.0
+by OJ Reeves (@TheColonial) & Christian Mehlmauer (@_FireFart_)
+===============================================================
+[+] Threads:                 10
+[+] Wordlist:                .\wordlist.txt
+[+] User Agent:              gobuster/3.1.0
+[+] Verbose:                 true
+[+] Timeout:                 10s
+[+] Maximum files to list:   5
+===============================================================
+2019/08/12 21:49:00 Starting gobuster in S3 bucket enumeration mode
+===============================================================
+www [Error: All access to this object has been disabled (AllAccessDisabled)]
+hacking [Error: Access Denied (AccessDenied)]
+css [Error: All access to this object has been disabled (AllAccessDisabled)]
+webmail [Error: All access to this object has been disabled (AllAccessDisabled)]
+img [Bucket Listing enabled: GodBlessPotomac1.jpg (1236807b), HOMEWORKOUTAUDIO.zip (203908818b), ProductionInfo.xml (11946b), Start of Perpetual Motion Logo-1.mp3 (621821b), addressbook.gif (3115b)]
+web [Error: Access Denied (AccessDenied)]
+dav [Error: All access to this object has been disabled (AllAccessDisabled)]
+localhost [Error: Access Denied (AccessDenied)]
+===============================================================
+2019/08/12 21:49:01 Finished
+===============================================================
+```
+
+Extended sample run
+
+```text
+PS C:\Users\firefart\Documents\code\gobuster> .\gobuster.exe s3 --wordlist .\wordlist.txt -e
+===============================================================
+Gobuster v3.1.0
+by OJ Reeves (@TheColonial) & Christian Mehlmauer (@_FireFart_)
+===============================================================
+[+] Threads:                 10
+[+] Wordlist:                .\wordlist.txt
+[+] User Agent:              gobuster/3.1.0
+[+] Timeout:                 10s
+[+] Expanded:                true
+[+] Maximum files to list:   5
+===============================================================
+2019/08/12 21:48:38 Starting gobuster in S3 bucket enumeration mode
+===============================================================
+http://css.s3.amazonaws.com/
+http://www.s3.amazonaws.com/
+http://webmail.s3.amazonaws.com/
+http://hacking.s3.amazonaws.com/
+http://img.s3.amazonaws.com/
+http://web.s3.amazonaws.com/
+http://dav.s3.amazonaws.com/
+http://localhost.s3.amazonaws.com/
+===============================================================
+2019/08/12 21:48:38 Finished
 ===============================================================
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All funds that are donated to this project will be donated to charity. A full lo
 ## Changes in 3.1
 
 * enumerate public AWS S3 buckets
+* specify HTTP method
 
 ## Changes in 3.0
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
 # TODO
 
 * no log.Printf inside of plugins
+* Add transformations to s3 bucket list like -dev -prod , .....

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
 # TODO
 
 * no log.Printf inside of plugins
-* Add transformations to s3 bucket list like -dev -prod , .....
+* Update expected requests on files and permutations (currently we only count the wordlist)

--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -76,7 +76,7 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 
 	// blacklist will override the normal status codes
 	if plugin.StatusCodesBlacklist != "" {
-		ret, err := helper.ParseStatusCodes(plugin.StatusCodesBlacklist)
+		ret, err := helper.ParseCommaSeperatedInt(plugin.StatusCodesBlacklist)
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid value for statuscodesblacklist: %v", err)
 		}
@@ -87,7 +87,7 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid value for statuscodes: %v", err)
 		}
-		ret, err := helper.ParseStatusCodes(plugin.StatusCodes)
+		ret, err := helper.ParseCommaSeperatedInt(plugin.StatusCodes)
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid value for statuscodes: %v", err)
 		}
@@ -125,7 +125,7 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 func init() {
 	cmdDir = &cobra.Command{
 		Use:   "dir",
-		Short: "Uses directory/file brutceforcing mode",
+		Short: "Uses directory/file enumeration mode",
 		RunE:  runDir,
 	}
 

--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -55,6 +55,7 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 	plugin.FollowRedirect = httpOpts.FollowRedirect
 	plugin.InsecureSSL = httpOpts.InsecureSSL
 	plugin.Headers = httpOpts.Headers
+	plugin.Method = httpOpts.Method
 
 	plugin.Extensions, err = cmdDir.Flags().GetString("extensions")
 	if err != nil {

--- a/cli/cmd/dir_test.go
+++ b/cli/cmd/dir_test.go
@@ -41,7 +41,7 @@ func BenchmarkDirMode(b *testing.B) {
 	pluginopts.ExtensionsParsed = tmpExt
 
 	pluginopts.StatusCodes = "200,204,301,302,307,401,403"
-	tmpStat, err := helper.ParseStatusCodes(pluginopts.StatusCodes)
+	tmpStat, err := helper.ParseCommaSeperatedInt(pluginopts.StatusCodes)
 	if err != nil {
 		b.Fatalf("could not parse status codes: %v", err)
 	}

--- a/cli/cmd/dns.go
+++ b/cli/cmd/dns.go
@@ -81,7 +81,7 @@ func parseDNSOptions() (*libgobuster.Options, *gobusterdns.OptionsDNS, error) {
 func init() {
 	cmdDNS = &cobra.Command{
 		Use:   "dns",
-		Short: "Uses DNS subdomain bruteforcing mode",
+		Short: "Uses DNS subdomain enumeration mode",
 		RunE:  runDNS,
 	}
 

--- a/cli/cmd/http.go
+++ b/cli/cmd/http.go
@@ -36,8 +36,8 @@ func addCommonHTTPOptions(cmd *cobra.Command) error {
 	return nil
 }
 
-func parseBasicHTTPOptions(cmd *cobra.Command) (libgobuster.OptionsHTTP, error) {
-	options := libgobuster.OptionsHTTP{}
+func parseBasicHTTPOptions(cmd *cobra.Command) (libgobuster.BasicHTTPOptions, error) {
+	options := libgobuster.BasicHTTPOptions{}
 	var err error
 
 	options.UserAgent, err = cmd.Flags().GetString("useragent")
@@ -57,8 +57,8 @@ func parseBasicHTTPOptions(cmd *cobra.Command) (libgobuster.OptionsHTTP, error) 
 	return options, nil
 }
 
-func parseCommonHTTPOptions(cmd *cobra.Command) (libgobuster.OptionsHTTP, error) {
-	options := libgobuster.OptionsHTTP{}
+func parseCommonHTTPOptions(cmd *cobra.Command) (libgobuster.HTTPOptions, error) {
+	options := libgobuster.HTTPOptions{}
 	var err error
 
 	basic, err := parseBasicHTTPOptions(cmd)

--- a/cli/cmd/http.go
+++ b/cli/cmd/http.go
@@ -30,7 +30,7 @@ func addCommonHTTPOptions(cmd *cobra.Command) error {
 	cmd.Flags().StringArrayP("headers", "H", []string{""}, "Specify HTTP headers, -H 'Header1: val1' -H 'Header2: val2'")
 	cmd.Flags().StringP("method", "m", "GET", "Use the following HTTP method")
 
-	if err := cmdDir.MarkFlagRequired("url"); err != nil {
+	if err := cmd.MarkFlagRequired("url"); err != nil {
 		return fmt.Errorf("error on marking flag as required: %v", err)
 	}
 

--- a/cli/cmd/http.go
+++ b/cli/cmd/http.go
@@ -15,7 +15,7 @@ import (
 
 func addBasicHTTPOptions(cmd *cobra.Command) {
 	cmd.Flags().StringP("useragent", "a", libgobuster.DefaultUserAgent(), "Set the User-Agent string")
-	cmd.Flags().StringP("proxy", "p", "", "Proxy to use for requests [http(s)://host:port]")
+	cmd.Flags().StringP("proxy", "", "", "Proxy to use for requests [http(s)://host:port]")
 	cmd.Flags().DurationP("timeout", "", 10*time.Second, "HTTP Timeout")
 }
 

--- a/cli/cmd/http.go
+++ b/cli/cmd/http.go
@@ -28,6 +28,7 @@ func addCommonHTTPOptions(cmd *cobra.Command) error {
 	cmd.Flags().BoolP("followredirect", "r", false, "Follow redirects")
 	cmd.Flags().BoolP("insecuressl", "k", false, "Skip SSL certificate verification")
 	cmd.Flags().StringArrayP("headers", "H", []string{""}, "Specify HTTP headers, -H 'Header1: val1' -H 'Header2: val2'")
+	cmd.Flags().StringP("method", "m", "GET", "Use the following HTTP method")
 
 	if err := cmdDir.MarkFlagRequired("url"); err != nil {
 		return fmt.Errorf("error on marking flag as required: %v", err)
@@ -117,6 +118,11 @@ func parseCommonHTTPOptions(cmd *cobra.Command) (libgobuster.HTTPOptions, error)
 	options.InsecureSSL, err = cmd.Flags().GetBool("insecuressl")
 	if err != nil {
 		return options, fmt.Errorf("invalid value for insecuressl: %v", err)
+	}
+
+	options.Method, err = cmd.Flags().GetString("method")
+	if err != nil {
+		return options, fmt.Errorf("invalid value for method: %v", err)
 	}
 
 	headers, err := cmd.Flags().GetStringArray("headers")

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -86,18 +86,18 @@ func parseGlobalOptions() (*libgobuster.Options, error) {
 		return nil, fmt.Errorf("wordlist file %q does not exist: %v", globalopts.Wordlist, err2)
 	}
 
-	perms, err := rootCmd.Flags().GetString("permutations")
+	globalopts.PermutationFile, err = rootCmd.Flags().GetString("permutations")
 	if err != nil {
 		return nil, fmt.Errorf("invalid value for permutations: %v", err)
 	}
 
-	if perms != "" {
-		if _, err = os.Stat(perms); os.IsNotExist(err) {
-			return nil, fmt.Errorf("permutation file %q does not exist: %v", perms, err)
+	if globalopts.PermutationFile != "" {
+		if _, err = os.Stat(globalopts.PermutationFile); os.IsNotExist(err) {
+			return nil, fmt.Errorf("permutation file %q does not exist: %v", globalopts.PermutationFile, err)
 		}
-		permFile, err := os.Open(perms)
+		permFile, err := os.Open(globalopts.PermutationFile)
 		if err != nil {
-			return nil, fmt.Errorf("could not open permutation file %q: %v", perms, err)
+			return nil, fmt.Errorf("could not open permutation file %q: %v", globalopts.PermutationFile, err)
 		}
 		defer permFile.Close()
 
@@ -106,7 +106,7 @@ func parseGlobalOptions() (*libgobuster.Options, error) {
 			globalopts.Permutations = append(globalopts.Permutations, scanner.Text())
 		}
 		if err := scanner.Err(); err != nil {
-			return nil, fmt.Errorf("could not read permutation file %q: %v", perms, err)
+			return nil, fmt.Errorf("could not read permutation file %q: %v", globalopts.PermutationFile, err)
 		}
 	}
 

--- a/cli/cmd/s3.go
+++ b/cli/cmd/s3.go
@@ -40,16 +40,10 @@ func parseS3Options() (*libgobuster.Options, *gobusters3.OptionsS3, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	plugin.Password = httpOpts.Password
-	plugin.URL = httpOpts.URL
+
 	plugin.UserAgent = httpOpts.UserAgent
-	plugin.Username = httpOpts.Username
 	plugin.Proxy = httpOpts.Proxy
-	plugin.Cookies = httpOpts.Cookies
 	plugin.Timeout = httpOpts.Timeout
-	plugin.FollowRedirect = httpOpts.FollowRedirect
-	plugin.InsecureSSL = httpOpts.InsecureSSL
-	plugin.Headers = httpOpts.Headers
 
 	plugin.MaxFilesToList, err = cmdS3.Flags().GetInt("maxfiles")
 	if err != nil {

--- a/cli/cmd/s3.go
+++ b/cli/cmd/s3.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/OJ/gobuster/v3/cli"
+	"github.com/OJ/gobuster/v3/gobusters3"
+	"github.com/OJ/gobuster/v3/libgobuster"
+	"github.com/spf13/cobra"
+)
+
+var cmdS3 *cobra.Command
+
+func runS3(cmd *cobra.Command, args []string) error {
+	globalopts, pluginopts, err := parseS3Options()
+	if err != nil {
+		return fmt.Errorf("error on parsing arguments: %v", err)
+	}
+
+	plugin, err := gobusters3.NewGobusterS3(mainContext, globalopts, pluginopts)
+	if err != nil {
+		return fmt.Errorf("error on creating gobusters3: %v", err)
+	}
+
+	if err := cli.Gobuster(mainContext, globalopts, plugin); err != nil {
+		return fmt.Errorf("error on running gobuster: %v", err)
+	}
+	return nil
+}
+
+func parseS3Options() (*libgobuster.Options, *gobusters3.OptionsS3, error) {
+	globalopts, err := parseGlobalOptions()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	plugin := gobusters3.NewOptionsS3()
+
+	httpOpts, err := parseBasicHTTPOptions(cmdS3)
+	if err != nil {
+		return nil, nil, err
+	}
+	plugin.Password = httpOpts.Password
+	plugin.URL = httpOpts.URL
+	plugin.UserAgent = httpOpts.UserAgent
+	plugin.Username = httpOpts.Username
+	plugin.Proxy = httpOpts.Proxy
+	plugin.Cookies = httpOpts.Cookies
+	plugin.Timeout = httpOpts.Timeout
+	plugin.FollowRedirect = httpOpts.FollowRedirect
+	plugin.InsecureSSL = httpOpts.InsecureSSL
+	plugin.Headers = httpOpts.Headers
+
+	plugin.MaxFilesToList, err = cmdS3.Flags().GetInt("maxfiles")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for maxfiles: %v", err)
+	}
+
+	plugin.Expanded, err = cmdS3.Flags().GetBool("expanded")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for expanded: %v", err)
+	}
+
+	return globalopts, plugin, nil
+}
+
+func init() {
+	cmdS3 = &cobra.Command{
+		Use:   "s3",
+		Short: "Uses aws bucket enumeration mode",
+		RunE:  runS3,
+	}
+
+	addBasicHTTPOptions(cmdS3)
+	cmdS3.Flags().IntP("maxfiles", "m", 5, "max files to list when listing buckets (only shown in verbose mode)")
+	cmdS3.Flags().BoolP("expanded", "e", false, "Expanded mode, print full bucket URLs")
+
+	cmdS3.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		configureGlobalOptions()
+	}
+
+	rootCmd.AddCommand(cmdS3)
+}

--- a/cli/cmd/vhost.go
+++ b/cli/cmd/vhost.go
@@ -57,7 +57,7 @@ func parseVhostOptions() (*libgobuster.Options, *gobustervhost.OptionsVhost, err
 func init() {
 	cmdVhost = &cobra.Command{
 		Use:   "vhost",
-		Short: "Uses VHOST bruteforcing mode",
+		Short: "Uses VHOST enumeration mode",
 		RunE:  runVhost,
 	}
 	if err := addCommonHTTPOptions(cmdVhost); err != nil {

--- a/cli/cmd/vhost.go
+++ b/cli/cmd/vhost.go
@@ -50,6 +50,7 @@ func parseVhostOptions() (*libgobuster.Options, *gobustervhost.OptionsVhost, err
 	plugin.FollowRedirect = httpOpts.FollowRedirect
 	plugin.InsecureSSL = httpOpts.InsecureSSL
 	plugin.Headers = httpOpts.Headers
+	plugin.Method = httpOpts.Method
 
 	return globalopts, &plugin, nil
 }

--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -121,7 +121,7 @@ func Gobuster(prevCtx context.Context, opts *libgobuster.Options, plugin libgobu
 		}
 		fmt.Println(c)
 		ruler()
-		gobuster.LogInfo.Println("Starting gobuster")
+		gobuster.LogInfo.Printf("Starting gobuster in %s mode", plugin.Name())
 		ruler()
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
-	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
+	golang.org/x/sys v0.0.0-20190812172437-4e8604ab3aff // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -15,6 +16,7 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -25,6 +27,7 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -32,12 +35,14 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 h1:LepdCS8Gf/MVejFIt8lsiexZATdoGVyp5bcyS+rYoUI=
-golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190812172437-4e8604ab3aff h1:u5LtynOOWSPG+jkEa3Y4ATlQ05vVeRvFjYSvbG0z6uw=
+golang.org/x/sys v0.0.0-20190812172437-4e8604ab3aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -71,6 +71,11 @@ func NewGobusterDir(cont context.Context, globalopts *libgobuster.Options, opts 
 	return &g, nil
 }
 
+// Name should return the name of the plugin
+func (d *GobusterDir) Name() string {
+	return "directory enumeration"
+}
+
 // PreRun is the pre run implementation of gobusterdir
 func (d *GobusterDir) PreRun() error {
 	// add trailing slash

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -270,6 +270,12 @@ func (d *GobusterDir) GetConfigString() (string, error) {
 		return "", err
 	}
 
+	if d.globalopts.PermutationFile != "" {
+		if _, err := fmt.Fprintf(tw, "[+] Permutations:\t%s (%d entries)\n", d.globalopts.PermutationFile, len(d.globalopts.Permutations)); err != nil {
+			return "", err
+		}
+	}
+
 	if o.StatusCodesBlacklistParsed.Length() > 0 {
 		if _, err := fmt.Fprintf(tw, "[+] Negative Status codes:\t%s\n", o.StatusCodesBlacklistParsed.Stringify()); err != nil {
 			return "", err

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -33,7 +33,7 @@ type GobusterDir struct {
 // get issues a GET request to the target and returns
 // the status code, length and an error
 func (d *GobusterDir) get(url string) (*int, *int64, error) {
-	return d.http.Get(url, "", d.options.Cookies)
+	return d.http.Get(url, "", d.options.IncludeLength)
 }
 
 // NewGobusterDir creates a new initialized GobusterDir
@@ -51,16 +51,20 @@ func NewGobusterDir(cont context.Context, globalopts *libgobuster.Options, opts 
 		globalopts: globalopts,
 	}
 
+	basicOptions := libgobuster.BasicHTTPOptions{
+		Proxy:     opts.Proxy,
+		Timeout:   opts.Timeout,
+		UserAgent: opts.UserAgent,
+	}
+
 	httpOpts := libgobuster.HTTPOptions{
-		Proxy:          opts.Proxy,
-		FollowRedirect: opts.FollowRedirect,
-		InsecureSSL:    opts.InsecureSSL,
-		IncludeLength:  opts.IncludeLength,
-		Timeout:        opts.Timeout,
-		Username:       opts.Username,
-		Password:       opts.Password,
-		UserAgent:      opts.UserAgent,
-		Headers:        opts.Headers,
+		BasicHTTPOptions: basicOptions,
+		FollowRedirect:   opts.FollowRedirect,
+		InsecureSSL:      opts.InsecureSSL,
+		Username:         opts.Username,
+		Password:         opts.Password,
+		Headers:          opts.Headers,
+		Cookies:          opts.Cookies,
 	}
 
 	h, err := libgobuster.NewHTTPClient(cont, &httpOpts)

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -30,7 +30,7 @@ type GobusterDir struct {
 	http       *libgobuster.HTTPClient
 }
 
-// GetRequest issues a GET request to the target and returns
+// get issues a GET request to the target and returns
 // the status code, length and an error
 func (d *GobusterDir) get(url string) (*int, *int64, error) {
 	return d.http.Get(url, "", d.options.Cookies)

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -6,7 +6,7 @@ import (
 
 // OptionsDir is the struct to hold all options for this plugin
 type OptionsDir struct {
-	libgobuster.OptionsHTTP
+	libgobuster.HTTPOptions
 	Extensions                 string
 	ExtensionsParsed           libgobuster.StringSet
 	StatusCodes                string

--- a/gobusterdns/gobusterdns.go
+++ b/gobusterdns/gobusterdns.go
@@ -220,6 +220,12 @@ func (d *GobusterDNS) GetConfigString() (string, error) {
 		return "", err
 	}
 
+	if d.globalopts.PermutationFile != "" {
+		if _, err := fmt.Fprintf(tw, "[+] Permutations:\t%s (%d entries)\n", d.globalopts.PermutationFile, len(d.globalopts.Permutations)); err != nil {
+			return "", err
+		}
+	}
+
 	if d.globalopts.Verbose {
 		if _, err := fmt.Fprintf(tw, "[+] Verbose:\ttrue\n"); err != nil {
 			return "", err

--- a/gobusterdns/gobusterdns.go
+++ b/gobusterdns/gobusterdns.go
@@ -71,6 +71,11 @@ func NewGobusterDNS(globalopts *libgobuster.Options, opts *OptionsDNS) (*Gobuste
 	return &g, nil
 }
 
+// Name should return the name of the plugin
+func (d *GobusterDNS) Name() string {
+	return "DNS enumeration"
+}
+
 // PreRun is the pre run implementation of gobusterdns
 func (d *GobusterDNS) PreRun() error {
 	// Resolve a subdomain sthat probably shouldn't exist

--- a/gobusters3/gobusters3.go
+++ b/gobusters3/gobusters3.go
@@ -21,8 +21,8 @@ type GobusterS3 struct {
 	bucketRegex *regexp.Regexp
 }
 
-// GetRequest issues a GET request to the target and returns
-// the status code, length and an error
+// get issues a GET request to the target and returns
+// the status code, body and an error
 func (s *GobusterS3) get(url string) (*int, *[]byte, error) {
 	return s.http.GetWithBody(url, "", s.options.Cookies)
 }

--- a/gobusters3/gobusters3.go
+++ b/gobusters3/gobusters3.go
@@ -79,7 +79,6 @@ func (s *GobusterS3) Run(word string) ([]libgobuster.Result, error) {
 		return ret, nil
 	}
 
-	// this url will return a 307 with the URL including the region if found
 	bucketURL := fmt.Sprintf("http://%s.s3.amazonaws.com/?max-keys=%d", word, s.options.MaxFilesToList)
 	status, body, err := s.get(bucketURL)
 	if err != nil {

--- a/gobusters3/gobusters3.go
+++ b/gobusters3/gobusters3.go
@@ -204,38 +204,20 @@ func (s *GobusterS3) GetConfigString() (string, error) {
 		}
 	}
 
-	if o.Cookies != "" {
-		if _, err := fmt.Fprintf(tw, "[+] Cookies:\t%s\n", o.Cookies); err != nil {
-			return "", err
-		}
-	}
-
 	if o.UserAgent != "" {
 		if _, err := fmt.Fprintf(tw, "[+] User Agent:\t%s\n", o.UserAgent); err != nil {
 			return "", err
 		}
 	}
 
-	if o.Username != "" {
-		if _, err := fmt.Fprintf(tw, "[+] Auth User:\t%s\n", o.Username); err != nil {
-			return "", err
-		}
-	}
-
-	if o.FollowRedirect {
-		if _, err := fmt.Fprintf(tw, "[+] Follow Redir:\ttrue\n"); err != nil {
-			return "", err
-		}
+	if _, err := fmt.Fprintf(tw, "[+] Timeout:\t%s\n", o.Timeout.String()); err != nil {
+		return "", err
 	}
 
 	if s.globalopts.Verbose {
 		if _, err := fmt.Fprintf(tw, "[+] Verbose:\ttrue\n"); err != nil {
 			return "", err
 		}
-	}
-
-	if _, err := fmt.Fprintf(tw, "[+] Timeout:\t%s\n", o.Timeout.String()); err != nil {
-		return "", err
 	}
 
 	if o.Expanded {

--- a/gobusters3/gobusters3.go
+++ b/gobusters3/gobusters3.go
@@ -196,6 +196,12 @@ func (s *GobusterS3) GetConfigString() (string, error) {
 		return "", err
 	}
 
+	if s.globalopts.PermutationFile != "" {
+		if _, err := fmt.Fprintf(tw, "[+] Permutations:\t%s (%d entries)\n", s.globalopts.PermutationFile, len(s.globalopts.Permutations)); err != nil {
+			return "", err
+		}
+	}
+
 	if o.Proxy != "" {
 		if _, err := fmt.Fprintf(tw, "[+] Proxy:\t%s\n", o.Proxy); err != nil {
 			return "", err

--- a/gobusters3/gobusters3.go
+++ b/gobusters3/gobusters3.go
@@ -24,7 +24,7 @@ type GobusterS3 struct {
 // get issues a GET request to the target and returns
 // the status code, body and an error
 func (s *GobusterS3) get(url string) (*int, *[]byte, error) {
-	return s.http.GetWithBody(url, "", s.options.Cookies)
+	return s.http.GetWithBody(url, "")
 }
 
 // NewGobusterS3 creates a new initialized GobusterS3
@@ -42,12 +42,16 @@ func NewGobusterS3(cont context.Context, globalopts *libgobuster.Options, opts *
 		globalopts: globalopts,
 	}
 
+	basicOptions := libgobuster.BasicHTTPOptions{
+		Proxy:     opts.Proxy,
+		Timeout:   opts.Timeout,
+		UserAgent: opts.UserAgent,
+	}
+
 	httpOpts := libgobuster.HTTPOptions{
-		Proxy: opts.Proxy,
+		BasicHTTPOptions: basicOptions,
 		// needed so we can list bucket contents
 		FollowRedirect: true,
-		Timeout:        opts.Timeout,
-		UserAgent:      opts.UserAgent,
 	}
 
 	h, err := libgobuster.NewHTTPClient(cont, &httpOpts)

--- a/gobusters3/gobusters3.go
+++ b/gobusters3/gobusters3.go
@@ -1,0 +1,277 @@
+package gobusters3
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"regexp"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/OJ/gobuster/v3/libgobuster"
+)
+
+// GobusterS3 is the main type to implement the interface
+type GobusterS3 struct {
+	options     *OptionsS3
+	globalopts  *libgobuster.Options
+	http        *libgobuster.HTTPClient
+	bucketRegex *regexp.Regexp
+}
+
+// GetRequest issues a GET request to the target and returns
+// the status code, length and an error
+func (s *GobusterS3) get(url string) (*int, *[]byte, error) {
+	return s.http.GetWithBody(url, "", s.options.Cookies)
+}
+
+// NewGobusterS3 creates a new initialized GobusterS3
+func NewGobusterS3(cont context.Context, globalopts *libgobuster.Options, opts *OptionsS3) (*GobusterS3, error) {
+	if globalopts == nil {
+		return nil, fmt.Errorf("please provide valid global options")
+	}
+
+	if opts == nil {
+		return nil, fmt.Errorf("please provide valid plugin options")
+	}
+
+	g := GobusterS3{
+		options:    opts,
+		globalopts: globalopts,
+	}
+
+	httpOpts := libgobuster.HTTPOptions{
+		Proxy: opts.Proxy,
+		// needed so we can list bucket contents
+		FollowRedirect: true,
+		Timeout:        opts.Timeout,
+		UserAgent:      opts.UserAgent,
+	}
+
+	h, err := libgobuster.NewHTTPClient(cont, &httpOpts)
+	if err != nil {
+		return nil, err
+	}
+	g.http = h
+	g.bucketRegex = regexp.MustCompile(`^[a-z0-9\-\.]{3,63}$`)
+
+	return &g, nil
+}
+
+// Name should return the name of the plugin
+func (s *GobusterS3) Name() string {
+	return "S3 bucket enumeration"
+}
+
+// PreRun is the pre run implementation of GobusterS3
+func (s *GobusterS3) PreRun() error {
+	return nil
+}
+
+// Run is the process implementation of GobusterS3
+func (s *GobusterS3) Run(word string) ([]libgobuster.Result, error) {
+	var ret []libgobuster.Result
+
+	// only check for valid bucket names
+	if !s.isValidBucketName(word) {
+		return ret, nil
+	}
+
+	// this url will return a 307 with the URL including the region if found
+	bucketURL := fmt.Sprintf("http://%s.s3.amazonaws.com/?max-keys=%d", word, s.options.MaxFilesToList)
+	status, body, err := s.get(bucketURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if status == nil || body == nil {
+		return ret, nil
+	}
+
+	// looks like 404 and 400 are the only negative status codes
+	found := false
+	switch *status {
+	case 400:
+	case 404:
+		found = false
+	case 200:
+		// listing enabled
+		found = true
+		// parse xml
+	default:
+		// default to found as we use negative status codes
+		found = true
+	}
+
+	// nothing found, bail out
+	// may add the result later if we want to enable verbose output
+	if !found {
+		return ret, nil
+	}
+
+	extraStr := ""
+	if s.globalopts.Verbose {
+		// get status
+		if bytes.Contains(*body, []byte("<Error>")) {
+			awsError := AWSError{}
+			err := xml.Unmarshal(*body, &awsError)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse error xml: %v", err)
+			}
+			// https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
+			extraStr = fmt.Sprintf("Error: %s (%s)", awsError.Message, awsError.Code)
+		} else if bytes.Contains(*body, []byte("<ListBucketResult ")) {
+			// bucket listing enabled
+			awsListing := AWSListing{}
+			err := xml.Unmarshal(*body, &awsListing)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse result xml: %v", err)
+			}
+			extraStr = "Bucket Listing enabled: "
+			for _, x := range awsListing.Contents {
+				extraStr += fmt.Sprintf("%s (%db), ", x.Key, x.Size)
+			}
+			extraStr = strings.TrimRight(extraStr, ", ")
+		}
+	}
+
+	ret = append(ret, libgobuster.Result{
+		Entity: word,
+		Status: libgobuster.StatusFound,
+		Extra:  extraStr,
+	})
+
+	return ret, nil
+}
+
+// ResultToString is the to string implementation of GobusterS3
+func (s *GobusterS3) ResultToString(r *libgobuster.Result) (*string, error) {
+	buf := &bytes.Buffer{}
+
+	if s.options.Expanded {
+		if _, err := fmt.Fprintf(buf, "http://%s.s3.amazonaws.com/", r.Entity); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := fmt.Fprintf(buf, "%s", r.Entity); err != nil {
+			return nil, err
+		}
+	}
+
+	if r.Extra != "" {
+		if _, err := fmt.Fprintf(buf, " [%s]", r.Extra); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, err := fmt.Fprintf(buf, "\n"); err != nil {
+		return nil, err
+	}
+
+	str := buf.String()
+	return &str, nil
+}
+
+// GetConfigString returns the string representation of the current config
+func (s *GobusterS3) GetConfigString() (string, error) {
+	var buffer bytes.Buffer
+	bw := bufio.NewWriter(&buffer)
+	tw := tabwriter.NewWriter(bw, 0, 5, 3, ' ', 0)
+	o := s.options
+
+	if _, err := fmt.Fprintf(tw, "[+] Threads:\t%d\n", s.globalopts.Threads); err != nil {
+		return "", err
+	}
+
+	if s.globalopts.Delay > 0 {
+		if _, err := fmt.Fprintf(tw, "[+] Delay:\t%s\n", s.globalopts.Delay); err != nil {
+			return "", err
+		}
+	}
+
+	wordlist := "stdin (pipe)"
+	if s.globalopts.Wordlist != "-" {
+		wordlist = s.globalopts.Wordlist
+	}
+	if _, err := fmt.Fprintf(tw, "[+] Wordlist:\t%s\n", wordlist); err != nil {
+		return "", err
+	}
+
+	if o.Proxy != "" {
+		if _, err := fmt.Fprintf(tw, "[+] Proxy:\t%s\n", o.Proxy); err != nil {
+			return "", err
+		}
+	}
+
+	if o.Cookies != "" {
+		if _, err := fmt.Fprintf(tw, "[+] Cookies:\t%s\n", o.Cookies); err != nil {
+			return "", err
+		}
+	}
+
+	if o.UserAgent != "" {
+		if _, err := fmt.Fprintf(tw, "[+] User Agent:\t%s\n", o.UserAgent); err != nil {
+			return "", err
+		}
+	}
+
+	if o.Username != "" {
+		if _, err := fmt.Fprintf(tw, "[+] Auth User:\t%s\n", o.Username); err != nil {
+			return "", err
+		}
+	}
+
+	if o.FollowRedirect {
+		if _, err := fmt.Fprintf(tw, "[+] Follow Redir:\ttrue\n"); err != nil {
+			return "", err
+		}
+	}
+
+	if s.globalopts.Verbose {
+		if _, err := fmt.Fprintf(tw, "[+] Verbose:\ttrue\n"); err != nil {
+			return "", err
+		}
+	}
+
+	if _, err := fmt.Fprintf(tw, "[+] Timeout:\t%s\n", o.Timeout.String()); err != nil {
+		return "", err
+	}
+
+	if o.Expanded {
+		if _, err := fmt.Fprintf(tw, "[+] Expanded:\ttrue\n"); err != nil {
+			return "", err
+		}
+	}
+
+	if _, err := fmt.Fprintf(tw, "[+] Maximum files to list:\t%d\n", o.MaxFilesToList); err != nil {
+		return "", err
+	}
+
+	if err := tw.Flush(); err != nil {
+		return "", fmt.Errorf("error on tostring: %v", err)
+	}
+
+	if err := bw.Flush(); err != nil {
+		return "", fmt.Errorf("error on tostring: %v", err)
+	}
+
+	return strings.TrimSpace(buffer.String()), nil
+}
+
+// https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+func (s *GobusterS3) isValidBucketName(bucketName string) bool {
+	if !s.bucketRegex.MatchString(bucketName) {
+		return false
+	}
+	if strings.HasSuffix(bucketName, "-") ||
+		strings.HasPrefix(bucketName, ".") ||
+		strings.HasPrefix(bucketName, "-") ||
+		strings.Contains(bucketName, "..") ||
+		strings.Contains(bucketName, ".-") ||
+		strings.Contains(bucketName, "-.") {
+		return false
+	}
+	return true
+}

--- a/gobusters3/options.go
+++ b/gobusters3/options.go
@@ -1,0 +1,17 @@
+package gobusters3
+
+import (
+	"github.com/OJ/gobuster/v3/libgobuster"
+)
+
+// OptionsS3 is the struct to hold all options for this plugin
+type OptionsS3 struct {
+	libgobuster.OptionsHTTP
+	MaxFilesToList int
+	Expanded       bool
+}
+
+// NewOptionsS3 returns a new initialized OptionsS3
+func NewOptionsS3() *OptionsS3 {
+	return &OptionsS3{}
+}

--- a/gobusters3/options.go
+++ b/gobusters3/options.go
@@ -6,7 +6,7 @@ import (
 
 // OptionsS3 is the struct to hold all options for this plugin
 type OptionsS3 struct {
-	libgobuster.OptionsHTTP
+	libgobuster.BasicHTTPOptions
 	MaxFilesToList int
 	Expanded       bool
 }

--- a/gobusters3/types.go
+++ b/gobusters3/types.go
@@ -1,0 +1,23 @@
+package gobusters3
+
+import "encoding/xml"
+
+type AWSError struct {
+	XMLName   xml.Name `xml:"Error"`
+	Code      string   `xml:"Code"`
+	Message   string   `xml:"Message"`
+	RequestID string   `xml:"RequestId"`
+	HostID    string   `xml:"HostId"`
+}
+
+// parse only a subset of returned properties
+type AWSListing struct {
+	XMLName     xml.Name `xml:"ListBucketResult"`
+	Name        string   `xml:"Name"`
+	IsTruncated string   `xml:"IsTruncated"`
+	Contents    []struct {
+		Key          string `xml:"Key"`
+		LastModified string `xml:"LastModified"`
+		Size         int    `xml:"Size"`
+	} `xml:"Contents"`
+}

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -57,6 +57,11 @@ func NewGobusterVhost(cont context.Context, globalopts *libgobuster.Options, opt
 	return &g, nil
 }
 
+// Name should return the name of the plugin
+func (v *GobusterVhost) Name() string {
+	return "VHOST enumeration"
+}
+
 // PreRun is the pre run implementation of gobusterdir
 func (v *GobusterVhost) PreRun() error {
 

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -176,6 +176,12 @@ func (v *GobusterVhost) GetConfigString() (string, error) {
 		return "", err
 	}
 
+	if v.globalopts.PermutationFile != "" {
+		if _, err := fmt.Fprintf(tw, "[+] Permutations:\t%s (%d entries)\n", v.globalopts.PermutationFile, len(v.globalopts.Permutations)); err != nil {
+			return "", err
+		}
+	}
+
 	if o.Proxy != "" {
 		if _, err := fmt.Fprintf(tw, "[+] Proxy:\t%s\n", o.Proxy); err != nil {
 			return "", err

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -38,15 +38,20 @@ func NewGobusterVhost(cont context.Context, globalopts *libgobuster.Options, opt
 		globalopts: globalopts,
 	}
 
+	basicOptions := libgobuster.BasicHTTPOptions{
+		Proxy:     opts.Proxy,
+		Timeout:   opts.Timeout,
+		UserAgent: opts.UserAgent,
+	}
+
 	httpOpts := libgobuster.HTTPOptions{
-		Proxy:          opts.Proxy,
-		FollowRedirect: opts.FollowRedirect,
-		InsecureSSL:    opts.InsecureSSL,
-		Timeout:        opts.Timeout,
-		Username:       opts.Username,
-		Password:       opts.Password,
-		UserAgent:      opts.UserAgent,
-		Headers:        opts.Headers,
+		BasicHTTPOptions: basicOptions,
+		FollowRedirect:   opts.FollowRedirect,
+		InsecureSSL:      opts.InsecureSSL,
+		Username:         opts.Username,
+		Password:         opts.Password,
+		Headers:          opts.Headers,
+		Cookies:          opts.Cookies,
 	}
 
 	h, err := libgobuster.NewHTTPClient(cont, &httpOpts)
@@ -77,7 +82,7 @@ func (v *GobusterVhost) PreRun() error {
 	v.domain = url.Host
 
 	// request default vhost for baseline1
-	_, tmp, err := v.http.GetWithBody(v.options.URL, "", v.options.Cookies)
+	_, tmp, err := v.http.GetWithBody(v.options.URL, "")
 	if err != nil {
 		return fmt.Errorf("unable to connect to %s: %v", v.options.URL, err)
 	}
@@ -85,7 +90,7 @@ func (v *GobusterVhost) PreRun() error {
 
 	// request non existent vhost for baseline2
 	subdomain := fmt.Sprintf("%s.%s", uuid.New(), v.domain)
-	_, tmp, err = v.http.GetWithBody(v.options.URL, subdomain, v.options.Cookies)
+	_, tmp, err = v.http.GetWithBody(v.options.URL, subdomain)
 	if err != nil {
 		return fmt.Errorf("unable to connect to %s: %v", v.options.URL, err)
 	}
@@ -96,7 +101,7 @@ func (v *GobusterVhost) PreRun() error {
 // Run is the process implementation of gobusterdir
 func (v *GobusterVhost) Run(word string) ([]libgobuster.Result, error) {
 	subdomain := fmt.Sprintf("%s.%s", word, v.domain)
-	status, body, err := v.http.GetWithBody(v.options.URL, subdomain, v.options.Cookies)
+	status, body, err := v.http.GetWithBody(v.options.URL, subdomain)
 	var ret []libgobuster.Result
 	if err != nil {
 		return ret, err

--- a/gobustervhost/options.go
+++ b/gobustervhost/options.go
@@ -6,5 +6,5 @@ import (
 
 // OptionsVhost is the struct to hold all options for this plugin
 type OptionsVhost struct {
-	libgobuster.OptionsHTTP
+	libgobuster.HTTPOptions
 }

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -24,7 +24,7 @@ func ParseExtensions(extensions string) (libgobuster.StringSet, error) {
 	return ret, nil
 }
 
-// ParseCommaSeperated parses the status codes provided as a comma separated list
+// ParseCommaSeperatedInt parses the status codes provided as a comma separated list
 func ParseCommaSeperatedInt(inputString string) (libgobuster.IntSet, error) {
 	if inputString == "" {
 		return libgobuster.IntSet{}, fmt.Errorf("invalid string provided")

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -24,20 +24,34 @@ func ParseExtensions(extensions string) (libgobuster.StringSet, error) {
 	return ret, nil
 }
 
-// ParseStatusCodes parses the status codes provided as a comma separated list
-func ParseStatusCodes(statuscodes string) (libgobuster.IntSet, error) {
-	if statuscodes == "" {
-		return libgobuster.IntSet{}, fmt.Errorf("invalid status code string provided")
+// ParseCommaSeperated parses the status codes provided as a comma separated list
+func ParseCommaSeperatedInt(inputString string) (libgobuster.IntSet, error) {
+	if inputString == "" {
+		return libgobuster.IntSet{}, fmt.Errorf("invalid string provided")
 	}
 
 	ret := libgobuster.NewIntSet()
-	for _, c := range strings.Split(statuscodes, ",") {
+	for _, c := range strings.Split(inputString, ",") {
 		c = strings.TrimSpace(c)
 		i, err := strconv.Atoi(c)
 		if err != nil {
-			return libgobuster.IntSet{}, fmt.Errorf("invalid status code given: %s", c)
+			return libgobuster.IntSet{}, fmt.Errorf("invalid string given: %s", c)
 		}
 		ret.Add(i)
+	}
+	return ret, nil
+}
+
+// ParseCommaSeperatedString parses the status codes provided as a comma separated list
+func ParseCommaSeperatedString(inputString string) (libgobuster.StringSet, error) {
+	if inputString == "" {
+		return libgobuster.StringSet{}, fmt.Errorf("invalid string provided")
+	}
+
+	ret := libgobuster.NewStringSet()
+	for _, c := range strings.Split(inputString, ",") {
+		c = strings.TrimSpace(c)
+		ret.Add(c)
 	}
 	return ret, nil
 }

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -37,7 +37,7 @@ func TestParseExtensions(t *testing.T) {
 	}
 }
 
-func TestParseStatusCodes(t *testing.T) {
+func TestParseCommaSeperatedInt(t *testing.T) {
 	t.Parallel()
 
 	var tt = []struct {
@@ -56,7 +56,7 @@ func TestParseStatusCodes(t *testing.T) {
 
 	for _, x := range tt {
 		t.Run(x.testName, func(t *testing.T) {
-			ret, err := ParseStatusCodes(x.stringCodes)
+			ret, err := ParseCommaSeperatedInt(x.stringCodes)
 			if x.expectedError != "" {
 				if err.Error() != x.expectedError {
 					t.Fatalf("Expected error %q but got %q", x.expectedError, err.Error())
@@ -91,7 +91,7 @@ func BenchmarkParseExtensions(b *testing.B) {
 	}
 }
 
-func BenchmarkParseStatusCodes(b *testing.B) {
+func BenchmarkParseCommaSeperatedInt(b *testing.B) {
 	var tt = []struct {
 		testName      string
 		stringCodes   string
@@ -109,7 +109,7 @@ func BenchmarkParseStatusCodes(b *testing.B) {
 	for _, x := range tt {
 		b.Run(x.testName, func(b2 *testing.B) {
 			for y := 0; y < b2.N; y++ {
-				_, _ = ParseStatusCodes(x.stringCodes)
+				_, _ = ParseCommaSeperatedInt(x.stringCodes)
 			}
 		})
 	}

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -49,9 +49,9 @@ func TestParseCommaSeperatedInt(t *testing.T) {
 		{"Valid codes", "200,100,202", libgobuster.IntSet{Set: map[int]bool{100: true, 200: true, 202: true}}, ""},
 		{"Spaces", "200, 100 , 202", libgobuster.IntSet{Set: map[int]bool{100: true, 200: true, 202: true}}, ""},
 		{"Double codes", "200, 100, 202, 100", libgobuster.IntSet{Set: map[int]bool{100: true, 200: true, 202: true}}, ""},
-		{"Invalid code", "200,AAA", libgobuster.NewIntSet(), "invalid status code given: AAA"},
-		{"Invalid integer", "2000000000000000000000000000000", libgobuster.NewIntSet(), "invalid status code given: 2000000000000000000000000000000"},
-		{"Empty string", "", libgobuster.NewIntSet(), "invalid status code string provided"},
+		{"Invalid code", "200,AAA", libgobuster.NewIntSet(), "invalid string given: AAA"},
+		{"Invalid integer", "2000000000000000000000000000000", libgobuster.NewIntSet(), "invalid string given: 2000000000000000000000000000000"},
+		{"Empty string", "", libgobuster.NewIntSet(), "invalid string provided"},
 	}
 
 	for _, x := range tt {
@@ -101,9 +101,9 @@ func BenchmarkParseCommaSeperatedInt(b *testing.B) {
 		{"Valid codes", "200,100,202", libgobuster.IntSet{Set: map[int]bool{100: true, 200: true, 202: true}}, ""},
 		{"Spaces", "200, 100 , 202", libgobuster.IntSet{Set: map[int]bool{100: true, 200: true, 202: true}}, ""},
 		{"Double codes", "200, 100, 202, 100", libgobuster.IntSet{Set: map[int]bool{100: true, 200: true, 202: true}}, ""},
-		{"Invalid code", "200,AAA", libgobuster.NewIntSet(), "invalid status code given: AAA"},
-		{"Invalid integer", "2000000000000000000000000000000", libgobuster.NewIntSet(), "invalid status code given: 2000000000000000000000000000000"},
-		{"Empty string", "", libgobuster.NewIntSet(), "invalid status code string provided"},
+		{"Invalid code", "200,AAA", libgobuster.NewIntSet(), "invalid string given: AAA"},
+		{"Invalid integer", "2000000000000000000000000000000", libgobuster.NewIntSet(), "invalid string given: 2000000000000000000000000000000"},
+		{"Empty string", "", libgobuster.NewIntSet(), "invalid string string provided"},
 	}
 
 	for _, x := range tt {

--- a/libgobuster/interfaces.go
+++ b/libgobuster/interfaces.go
@@ -2,6 +2,7 @@ package libgobuster
 
 // GobusterPlugin is an interface which plugins must implement
 type GobusterPlugin interface {
+	Name() string
 	PreRun() error
 	Run(string) ([]Result, error)
 	ResultToString(*Result) (*string, error)

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -139,8 +139,14 @@ func (g *Gobuster) getWordlist() (*bufio.Scanner, error) {
 		return nil, fmt.Errorf("failed to get number of lines: %v", err)
 	}
 
-	g.requestsExpected = lines
 	g.requestsIssued = 0
+
+	// calcutate expected requests
+	if g.Opts.PermutationFile == "" {
+		g.requestsExpected = lines * len(g.Opts.Permutations)
+	} else {
+		g.requestsExpected = lines
+	}
 
 	// rewind wordlist
 	_, err = wordlist.Seek(0, 0)

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -203,7 +203,7 @@ func (g *Gobuster) GetConfigString() (string, error) {
 }
 
 func (g *Gobuster) makePermutations(word string) []string {
-	if len(g.Opts.Permutations) == 0 {
+	if g.Opts.PermutationFile == "" {
 		return nil
 	}
 

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -142,10 +142,9 @@ func (g *Gobuster) getWordlist() (*bufio.Scanner, error) {
 	g.requestsIssued = 0
 
 	// calcutate expected requests
+	g.requestsExpected = lines
 	if g.Opts.PermutationFile != "" {
-		g.requestsExpected = lines * len(g.Opts.Permutations)
-	} else {
-		g.requestsExpected = lines
+		g.requestsExpected += (lines * len(g.Opts.Permutations))
 	}
 
 	// rewind wordlist

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -181,7 +181,15 @@ Scan:
 		select {
 		case <-g.context.Done():
 			break Scan
-		case wordChan <- scanner.Text():
+		default:
+			word := scanner.Text()
+			perms := g.makePermutations(word)
+			// add the original word
+			wordChan <- word
+			// now create perms
+			for _, w := range perms {
+				wordChan <- w
+			}
 		}
 	}
 	close(wordChan)
@@ -192,4 +200,18 @@ Scan:
 // GetConfigString returns the current config as a printable string
 func (g *Gobuster) GetConfigString() (string, error) {
 	return g.plugin.GetConfigString()
+}
+
+func (g *Gobuster) makePermutations(word string) []string {
+	if len(g.Opts.Permutations) == 0 {
+		return nil
+	}
+
+	//nolint:prealloc
+	var perms []string
+	for _, x := range g.Opts.Permutations {
+		repl := strings.ReplaceAll(x, "{GOBUSTER}", word)
+		perms = append(perms, repl)
+	}
+	return perms
 }

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -142,7 +142,7 @@ func (g *Gobuster) getWordlist() (*bufio.Scanner, error) {
 	g.requestsIssued = 0
 
 	// calcutate expected requests
-	if g.Opts.PermutationFile == "" {
+	if g.Opts.PermutationFile != "" {
 		g.requestsExpected = lines * len(g.Opts.Permutations)
 	} else {
 		g.requestsExpected = lines

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -6,6 +6,7 @@ import "time"
 type Options struct {
 	Threads        int
 	Wordlist       string
+	Permutations   []string
 	OutputFilename string
 	NoStatus       bool
 	NoProgress     bool

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -4,16 +4,17 @@ import "time"
 
 // Options helds all options that can be passed to libgobuster
 type Options struct {
-	Threads        int
-	Wordlist       string
-	Permutations   []string
-	OutputFilename string
-	NoStatus       bool
-	NoProgress     bool
-	Quiet          bool
-	WildcardForced bool
-	Verbose        bool
-	Delay          time.Duration
+	Threads         int
+	Wordlist        string
+	PermutationFile string
+	Permutations    []string
+	OutputFilename  string
+	NoStatus        bool
+	NoProgress      bool
+	Quiet           bool
+	WildcardForced  bool
+	Verbose         bool
+	Delay           time.Duration
 }
 
 // NewOptions returns a new initialized Options object

--- a/libgobuster/options_http.go
+++ b/libgobuster/options_http.go
@@ -4,16 +4,21 @@ import (
 	"time"
 )
 
-// OptionsHTTP is the struct to hold all options for common HTTP options
-type OptionsHTTP struct {
+// BasicHTTPOptions defines only core http options
+type BasicHTTPOptions struct {
+	UserAgent string
+	Proxy     string
+	Timeout   time.Duration
+}
+
+// HTTPOptions is the struct to pass in all http options to Gobuster
+type HTTPOptions struct {
+	BasicHTTPOptions
 	Password       string
 	URL            string
-	UserAgent      string
 	Username       string
-	Proxy          string
 	Cookies        string
 	Headers        []HTTPHeader
-	Timeout        time.Duration
 	FollowRedirect bool
 	InsecureSSL    bool
 }

--- a/libgobuster/options_http.go
+++ b/libgobuster/options_http.go
@@ -21,4 +21,5 @@ type HTTPOptions struct {
 	Headers        []HTTPHeader
 	FollowRedirect bool
 	InsecureSSL    bool
+	Method         string
 }

--- a/libgobuster/version.go
+++ b/libgobuster/version.go
@@ -2,5 +2,5 @@ package libgobuster
 
 const (
 	// VERSION contains the current gobuster version
-	VERSION = "3.0.1"
+	VERSION = "3.1.0"
 )


### PR DESCRIPTION
This adds the feature of permutations to gobuster

Example permutation file:
```text
{GOBUSTER}Partial
{GOBUSTER}Service
PRE{GOBUSTER}POST
{GOBUSTER}-prod
{GOBUSTER}-dev
```

This branch is based off the `post` branch
https://github.com/OJ/gobuster/compare/post...permutations