### PR TITLE
Handle TLS renegotiation

### DIFF
--- a/libgobuster/http.go
+++ b/libgobuster/http.go
@@ -73,6 +73,7 @@ func NewHTTPClient(c context.Context, opt *HTTPOptions) (*HTTPClient, error) {
 			MaxIdleConnsPerHost: 100,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: opt.InsecureSSL,
+				Renegotiation: tls.RenegotiateFreelyAsClient,
 			},
 		}}
 	client.context = c


### PR DESCRIPTION
This allows Gobuster to establish a connection with a server that initiates TLS renegotiation. It may be desirable to make this behavior a toggle within OptionsHTTP.

Currently, Gobuster will kill scans that encounter TLS renegotiation during PreRun. This can be recreated by enumerating directories on some web servers which require client certificates.
``` console
gobuster -u https://server.cryptomix.com/secure/ -w test
```
Which should error immediately
``` console
Error: error on running gobuster: unable to connect to https://server.cryptomix.com/secure/: Get https://server.cryptomix.com/secure/: local error: tls: no renegotiation
exit status 1
```