### PR TITLE
Added Discovery Option to DIR Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Flags:
   -u, --url string                    The target URL
   -a, --useragent string              Set the User-Agent string (default "gobuster/3.0.1")
   -U, --username string               Username for Basic Auth
+  -d, --discoverbackup                Upon finding a file search for backup files
       --wildcard                      Force continued operation when wildcard found
 
 Global Flags:

--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -120,6 +120,11 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 		return nil, nil, fmt.Errorf("invalid value for wildcard: %v", err)
 	}
 
+        plugin.DiscoverBackup, err = cmdDir.Flags().GetBool("discoverbackup")
+        if err != nil {
+                return nil, nil, fmt.Errorf("invalid value for discoverbackup: %v", err)
+        }
+
 	return globalopts, plugin, nil
 }
 
@@ -141,6 +146,7 @@ func init() {
 	cmdDir.Flags().BoolP("includelength", "l", false, "Include the length of the body in the output")
 	cmdDir.Flags().BoolP("addslash", "f", false, "Append / to each request")
 	cmdDir.Flags().BoolP("wildcard", "", false, "Force continued operation when wildcard found")
+	cmdDir.Flags().BoolP("discoverbackup", "d", false, "Upon finding a file search for backup files")
 
 	cmdDir.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		configureGlobalOptions()

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -18,6 +18,7 @@ type OptionsDir struct {
 	IncludeLength              bool
 	Expanded                   bool
 	NoStatus                   bool
+	DiscoverBackup             bool
 }
 
 // NewOptionsDir returns a new initialized OptionsDir


### PR DESCRIPTION
NOTE: This is a duplicate from #200, I just moved and tested it over to the v3.1-working branch.

Added the -d flag to DiscoverContent. This will take all files with HTTP FOUND Status Codes and then mutate the file to find backup copies.

Example:
index.php ->

index.php~
index.php.bak
index.bak
.index.php.swp