### PR TITLE
Goroutine And Tip

### DIFF
--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -179,10 +179,8 @@ func Gobuster(prevCtx context.Context, opts *libgobuster.Options, plugin libgobu
 		MaxCharsWritten: 0,
 	}
 
-	wg.Add(1)
+	wg.Add(2)
 	go resultWorker(gobuster, opts.OutputFilename, &wg, o)
-
-	wg.Add(1)
 	go errorWorker(gobuster, &wg, o)
 
 	if !opts.Quiet && !opts.NoProgress {


### PR DESCRIPTION
# 1. Line: 182 Goroutine
There is no need to call "Add()" twice and you can only call it once and inform that there will be two Goroutines.

Note: From what I learned from Goroutine, in this case there is no need to have two calls. I don't know if they did it for any specific reason.

# 2 Variables - Tip
I thought about changing the names of the variables, instead of just a letter, putting a real name, more readable and understandable.