### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ Flags:
   -r, --follow-redirect               Follow redirects
   -H, --headers stringArray           Specify HTTP headers, -H 'Header1: val1' -H 'Header2: val2'
   -h, --help                          help for dir
-  -l, --include-length                Include the length of the body in the output
   -k, --no-tls-validation             Skip TLS certificate verification
   -n, --no-status                     Don't print status codes
   -P, --password string               Password for Basic Auth

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Help is built-in!
 ## `dns` Mode Help
 
 ```text
+Uses DNS subdomain enumeration mode
+
 Usage:
   gobuster dns [flags]
 
@@ -85,48 +87,59 @@ Flags:
       --wildcard           Force continued operation when wildcard found
 
 Global Flags:
+      --delay duration    Time each thread waits between requests (e.g. 1500ms)
+      --no-error          Don't display errors
   -z, --no-progress       Don't display progress
   -o, --output string     Output file to write results to (defaults to stdout)
+  -p, --pattern string    File containing replacement patterns
   -q, --quiet             Don't print the banner and other noise
   -t, --threads int       Number of concurrent threads (default 10)
-      --delay duration    Time each thread waits between requests (e.g. 1500ms)
   -v, --verbose           Verbose output (errors)
   -w, --wordlist string   Path to the wordlist
+
 ```
 
 ## `dir` Mode Options
 
 ```text
-Usage:
+Uses directory/file enumeration mode                                                  
+                                                                                      
+Usage:                                                                                
   gobuster dir [flags]
-
+                                                                                      
 Flags:
-  -f, --add-slash                     Append / to each request
-  -c, --cookies string                Cookies to use for the requests
-  -e, --expanded                      Expanded mode, print full URLs
-  -x, --extensions string             File extension(s) to search for
-  -r, --follow-redirect               Follow redirects
-  -H, --headers stringArray           Specify HTTP headers, -H 'Header1: val1' -H 'Header2: val2'
-  -h, --help                          help for dir
-  -k, --no-tls-validation             Skip TLS certificate verification
-  -n, --no-status                     Don't print status codes
-  -P, --password string               Password for Basic Auth
-  -p, --proxy string                  Proxy to use for requests [http(s)://host:port]
-  -s, --status-codes string           Positive status codes (will be overwritten with status-codes-blacklist if set) (default "200,204,301,302,307,401,403")
-  -b, --status-codes-blacklist string Negative status codes (will override status-codes if set)
-      --timeout duration              HTTP Timeout (default 10s)
-  -u, --url string                    The target URL
-  -a, --useragent string              Set the User-Agent string (default "gobuster/3.1.0")
-  -U, --username string               Username for Basic Auth
-  -d, --discover-backup               Upon finding a file search for backup files
-      --wildcard                      Force continued operation when wildcard found
+  -f, --add-slash                       Append / to each request
+  -c, --cookies string                  Cookies to use for the requests
+  -d, --discover-backup                 Upon finding a file search for backup files
+      --exclude-length ints             exclude the following content length (completely ignores the status). Supply multiple times to exclude multiple sizes.
+  -e, --expanded                        Expanded mode, print full URLs
+  -x, --extensions string               File extension(s) to search for
+  -r, --follow-redirect                 Follow redirects
+  -H, --headers stringArray             Specify HTTP headers, -H 'Header1: val1' -H 'Header2: val2'
+  -h, --help                            help for dir
+      --hide-length                     Hide the length of the body in the output
+  -m, --method string                   Use the following HTTP method (default "GET")
+  -n, --no-status                       Don't print status codes
+  -k, --no-tls-validation               Skip TLS certificate verification
+  -P, --password string                 Password for Basic Auth
+      --proxy string                    Proxy to use for requests [http(s)://host:port]
+      --random-agent                    Use a random User-Agent string
+  -s, --status-codes string             Positive status codes (will be overwritten with status-codes-blacklist if set)
+  -b, --status-codes-blacklist string   Negative status codes (will override status-codes if set) (default "404")
+      --timeout duration                HTTP Timeout (default 10s)
+  -u, --url string                      The target URL
+  -a, --useragent string                Set the User-Agent string (default "gobuster/3.1.0")
+  -U, --username string                 Username for Basic Auth
+      --wildcard                        Force continued operation when wildcard found
 
 Global Flags:
+      --delay duration    Time each thread waits between requests (e.g. 1500ms)
+      --no-error          Don't display errors
   -z, --no-progress       Don't display progress
   -o, --output string     Output file to write results to (defaults to stdout)
+  -p, --pattern string    File containing replacement patterns
   -q, --quiet             Don't print the banner and other noise
   -t, --threads int       Number of concurrent threads (default 10)
-      --delay duration    Time each thread waits between requests (e.g. 1500ms)
   -v, --verbose           Verbose output (errors)
   -w, --wordlist string   Path to the wordlist
 ```
@@ -134,6 +147,8 @@ Global Flags:
 ## `vhost` Mode Options
 
 ```text
+Uses VHOST enumeration mode
+
 Usage:
   gobuster vhost [flags]
 
@@ -142,20 +157,24 @@ Flags:
   -r, --follow-redirect       Follow redirects
   -H, --headers stringArray   Specify HTTP headers, -H 'Header1: val1' -H 'Header2: val2'
   -h, --help                  help for vhost
+  -m, --method string         Use the following HTTP method (default "GET")
   -k, --no-tls-validation     Skip TLS certificate verification
   -P, --password string       Password for Basic Auth
-  -p, --proxy string          Proxy to use for requests [http(s)://host:port]
+      --proxy string          Proxy to use for requests [http(s)://host:port]
+      --random-agent          Use a random User-Agent string
       --timeout duration      HTTP Timeout (default 10s)
   -u, --url string            The target URL
   -a, --useragent string      Set the User-Agent string (default "gobuster/3.1.0")
   -U, --username string       Username for Basic Auth
 
 Global Flags:
+      --delay duration    Time each thread waits between requests (e.g. 1500ms)
+      --no-error          Don't display errors
   -z, --no-progress       Don't display progress
   -o, --output string     Output file to write results to (defaults to stdout)
+  -p, --pattern string    File containing replacement patterns
   -q, --quiet             Don't print the banner and other noise
   -t, --threads int       Number of concurrent threads (default 10)
-      --delay duration    Time each thread waits between requests (e.g. 1500ms)
   -v, --verbose           Verbose output (errors)
   -w, --wordlist string   Path to the wordlist
 ```


### PR DESCRIPTION
version v3.1.0 of gobuster does not include the -l flag and shows length by default