### PR TITLE
Ability to add query string to each request

### DIFF
--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/OJ/gobuster/v3/cli"
 	"github.com/OJ/gobuster/v3/gobusterdir"
@@ -75,6 +76,18 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 	plugin.StatusCodesBlacklist, err = cmdDir.Flags().GetString("status-codes-blacklist")
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid value for status-codes-blacklist: %w", err)
+	}
+
+	plugin.QueryString, err = cmdDir.Flags().GetString("query")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid query string")
+	}
+	if plugin.QueryString != "" {
+		if strings.HasSuffix(plugin.URL, "/") {
+			plugin.URL = plugin.URL + "?" + plugin.QueryString
+		} else {
+			plugin.URL = plugin.URL + "/?" + plugin.QueryString
+		}
 	}
 
 	// blacklist will override the normal status codes
@@ -155,7 +168,7 @@ func init() {
 	cmdDir.Flags().Bool("wildcard", false, "Force continued operation when wildcard found")
 	cmdDir.Flags().BoolP("discover-backup", "d", false, "Upon finding a file search for backup files")
 	cmdDir.Flags().IntSlice("exclude-length", []int{}, "exclude the following content length (completely ignores the status). Supply multiple times to exclude multiple sizes.")
-
+	cmdDir.Flags().StringP("query", "Q", "", "Specify a query string to be added to the end of each request")
 	cmdDir.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		configureGlobalOptions()
 	}

--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -86,7 +86,7 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 		if strings.HasSuffix(plugin.URL, "/") {
 			plugin.URL = plugin.URL + "?" + plugin.QueryString
 		} else {
-			plugin.URL = plugin.URL + "/?" + plugin.QueryString
+			plugin.URL = plugin.URL + "?" + plugin.QueryString
 		}
 	}
 

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 	"text/tabwriter"
@@ -113,7 +112,7 @@ func (d *GobusterDir) PreRun() error {
 	if strings.Contains(d.options.URL, "?") {
 		resp, err := http.Get(d.options.URL)
 		if err != nil {
-			log.Fatalf("http.Get => %v", err.Error())
+			fmt.Printf(err.Error())
 		}
 
 		// Your magic function. The Request in the Response is the last URL the

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -119,6 +119,7 @@ func (d *GobusterDir) PreRun() error {
 		// client tried to access.
 		finalURL := resp.Request.URL.String()
 		d.options.URL = finalURL
+		fmt.Println(d.options.URL)
 	}
 	if !strings.HasSuffix(d.options.URL, "/") {
 		d.options.URL = fmt.Sprintf("%s/", d.options.URL)

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"net/http"
 	"strings"
 	"text/tabwriter"
 
@@ -108,6 +110,17 @@ func (d *GobusterDir) RequestsPerRun() int {
 // PreRun is the pre run implementation of gobusterdir
 func (d *GobusterDir) PreRun() error {
 	// add trailing slash
+	if strings.Contains(d.options.URL, "?") {
+		resp, err := http.Get(d.options.URL)
+		if err != nil {
+			log.Fatalf("http.Get => %v", err.Error())
+		}
+
+		// Your magic function. The Request in the Response is the last URL the
+		// client tried to access.
+		finalURL := resp.Request.URL.String()
+		d.options.URL = finalURL
+	}
 	if !strings.HasSuffix(d.options.URL, "/") {
 		d.options.URL = fmt.Sprintf("%s/", d.options.URL)
 	}

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -12,6 +12,7 @@ type OptionsDir struct {
 	StatusCodes                string
 	StatusCodesParsed          libgobuster.IntSet
 	StatusCodesBlacklist       string
+	QueryString                string
 	StatusCodesBlacklistParsed libgobuster.IntSet
 	UseSlash                   bool
 	WildcardForced             bool


### PR DESCRIPTION
This PR resolves the issue #227 , however not really sure on how he wanted it to be implemented so a little bit of guidance in here could be helpful , like should the url be something like 
` http://example.com/api/v1?secret=blargh` and the directory enumerations will be from the redirected url after there on ? or should this be something else?