### PR TITLE
Added retry option for timeout errors

### DIFF
--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -59,6 +59,8 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 	plugin.NoTLSValidation = httpOpts.NoTLSValidation
 	plugin.Headers = httpOpts.Headers
 	plugin.Method = httpOpts.Method
+	plugin.RetryOnTimeout = httpOpts.RetryOnTimeout
+	plugin.RetryAttempts = httpOpts.RetryAttempts
 
 	plugin.Extensions, err = cmdDir.Flags().GetString("extensions")
 	if err != nil {

--- a/cli/cmd/fuzz.go
+++ b/cli/cmd/fuzz.go
@@ -59,6 +59,8 @@ func parseFuzzOptions() (*libgobuster.Options, *gobusterfuzz.OptionsFuzz, error)
 	plugin.NoTLSValidation = httpOpts.NoTLSValidation
 	plugin.Headers = httpOpts.Headers
 	plugin.Method = httpOpts.Method
+	plugin.RetryOnTimeout = httpOpts.RetryOnTimeout
+	plugin.RetryAttempts = httpOpts.RetryAttempts
 
 	// blacklist will override the normal status codes
 	plugin.ExcludedStatusCodes, err = cmdFuzz.Flags().GetString("excludestatuscodes")

--- a/cli/cmd/http.go
+++ b/cli/cmd/http.go
@@ -20,6 +20,8 @@ func addBasicHTTPOptions(cmd *cobra.Command) {
 	cmd.Flags().StringP("proxy", "", "", "Proxy to use for requests [http(s)://host:port]")
 	cmd.Flags().DurationP("timeout", "", 10*time.Second, "HTTP Timeout")
 	cmd.Flags().BoolP("no-tls-validation", "k", false, "Skip TLS certificate verification")
+	cmd.Flags().BoolP("retry", "", false, "Should retry on request timeout")
+	cmd.Flags().IntP("retry-attempts", "", 3, "Times to retry on request timeout")
 }
 
 func addCommonHTTPOptions(cmd *cobra.Command) error {
@@ -69,6 +71,16 @@ func parseBasicHTTPOptions(cmd *cobra.Command) (libgobuster.BasicHTTPOptions, er
 		return options, fmt.Errorf("invalid value for timeout: %w", err)
 	}
 
+	options.RetryOnTimeout, err = cmd.Flags().GetBool("retry")
+	if err != nil {
+		return options, fmt.Errorf("invalid value for retry: %w", err)
+	}
+
+	options.RetryAttempts, err = cmd.Flags().GetInt("retry-attempts")
+	if err != nil {
+		return options, fmt.Errorf("invalid value for retry-attempts: %w", err)
+	}
+
 	options.NoTLSValidation, err = cmd.Flags().GetBool("no-tls-validation")
 	if err != nil {
 		return options, fmt.Errorf("invalid value for no-tls-validation: %w", err)
@@ -88,6 +100,8 @@ func parseCommonHTTPOptions(cmd *cobra.Command) (libgobuster.HTTPOptions, error)
 	options.Timeout = basic.Timeout
 	options.UserAgent = basic.UserAgent
 	options.NoTLSValidation = basic.NoTLSValidation
+	options.RetryOnTimeout = basic.RetryOnTimeout
+	options.RetryAttempts = basic.RetryAttempts
 
 	options.URL, err = cmd.Flags().GetString("url")
 	if err != nil {

--- a/cli/cmd/s3.go
+++ b/cli/cmd/s3.go
@@ -46,6 +46,8 @@ func parseS3Options() (*libgobuster.Options, *gobusters3.OptionsS3, error) {
 	plugin.Proxy = httpOpts.Proxy
 	plugin.Timeout = httpOpts.Timeout
 	plugin.NoTLSValidation = httpOpts.NoTLSValidation
+	plugin.RetryOnTimeout = httpOpts.RetryOnTimeout
+	plugin.RetryAttempts = httpOpts.RetryAttempts
 
 	plugin.MaxFilesToList, err = cmdS3.Flags().GetInt("maxfiles")
 	if err != nil {

--- a/cli/cmd/vhost.go
+++ b/cli/cmd/vhost.go
@@ -52,6 +52,8 @@ func parseVhostOptions() (*libgobuster.Options, *gobustervhost.OptionsVhost, err
 	plugin.NoTLSValidation = httpOpts.NoTLSValidation
 	plugin.Headers = httpOpts.Headers
 	plugin.Method = httpOpts.Method
+	plugin.RetryOnTimeout = httpOpts.RetryOnTimeout
+	plugin.RetryAttempts = httpOpts.RetryAttempts
 
 	plugin.AppendDomain, err = cmdVhost.Flags().GetBool("append-domain")
 	if err != nil {

--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -84,7 +84,15 @@ func errorWorker(g *libgobuster.Gobuster, wg *sync.WaitGroup, output *outputType
 	for e := range g.Errors() {
 		if !g.Opts.Quiet && !g.Opts.NoError {
 			output.Mu.Lock()
-			g.LogError.Printf("[!] %v", e)
+			s := fmt.Sprintf("[!] %s\n", e.Error())
+			s = rightPad(s, " ", output.MaxCharsWritten)
+
+			charsWritten := len(s) - 1
+			if charsWritten > output.MaxCharsWritten {
+				output.MaxCharsWritten = charsWritten
+			}
+
+			g.LogError.Print(s)
 			output.Mu.Unlock()
 		}
 	}

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -198,6 +198,15 @@ func (d *GobusterDir) Run(ctx context.Context, word string, resChannel chan<- li
 
 	for entity, url := range urlsToCheck {
 		statusCode, size, header, _, err := d.http.Request(ctx, url, libgobuster.RequestOptions{})
+
+		for i := 0; d.options.RetryOnTimeout &&
+			// should try again
+			(i < d.options.RetryAttempts || d.options.RetryAttempts == -1) &&
+			// timeout error
+			err != nil && strings.HasSuffix(err.Error(), "(Client.Timeout exceeded while awaiting headers)"); i++ {
+			statusCode, size, header, _, err = d.http.Request(ctx, url, libgobuster.RequestOptions{})
+		}
+
 		if err != nil {
 			return err
 		}

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -118,6 +118,15 @@ func (v *GobusterVhost) Run(ctx context.Context, word string, resChannel chan<- 
 		subdomain = word
 	}
 	status, size, header, body, err := v.http.Request(ctx, v.options.URL, libgobuster.RequestOptions{Host: subdomain, ReturnBody: true})
+
+	for i := 0; v.options.RetryOnTimeout &&
+		// should try again
+		(i < v.options.RetryAttempts || v.options.RetryAttempts == -1) &&
+		// timeout error
+		err != nil && strings.HasSuffix(err.Error(), "(Client.Timeout exceeded while awaiting headers)"); i++ {
+		status, size, header, body, err = v.http.Request(ctx, v.options.URL, libgobuster.RequestOptions{Host: subdomain, ReturnBody: true})
+	}
+
 	if err != nil {
 		return err
 	}

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -45,7 +45,7 @@ func NewGobuster(opts *Options, plugin GobusterPlugin) (*Gobuster, error) {
 	g.resultChan = make(chan Result)
 	g.errorChan = make(chan error)
 	g.LogInfo = log.New(os.Stdout, "", log.LstdFlags)
-	g.LogError = log.New(os.Stderr, "[ERROR] ", log.LstdFlags)
+	g.LogError = log.New(os.Stderr, "\r[ERROR] ", log.LstdFlags)
 
 	return &g, nil
 }

--- a/libgobuster/options_http.go
+++ b/libgobuster/options_http.go
@@ -10,6 +10,8 @@ type BasicHTTPOptions struct {
 	Proxy           string
 	NoTLSValidation bool
 	Timeout         time.Duration
+	RetryOnTimeout  bool
+	RetryAttempts   int
 }
 
 // HTTPOptions is the struct to pass in all http options to Gobuster


### PR DESCRIPTION
Will try sending the request again if retry option is specified. 
Adds two options:
```
      --retry                           Should retry on request timeout
      --retry-attempts int              Times to retry on request timeout (default 3)
```

Also fixed errors jamming progress bar with `\r`
