### PR TITLE
Exclude Length Range for Directory Enumeration

### DIFF
--- a/cli/cmd/dir.go
+++ b/cli/cmd/dir.go
@@ -127,7 +127,12 @@ func parseDirOptions() (*libgobuster.Options, *gobusterdir.OptionsDir, error) {
 
 	plugin.ExcludeLength, err = cmdDir.Flags().GetIntSlice("exclude-length")
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid value for excludelength: %w", err)
+		return nil, nil, fmt.Errorf("invalid value for exclude-length: %w", err)
+	}
+
+	plugin.ExcludeLengthRange, err = cmdDir.Flags().GetInt("exclude-length-range")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for exclude-length-range: %w", err)
 	}
 
 	return globalopts, plugin, nil
@@ -153,6 +158,8 @@ func init() {
 	cmdDir.Flags().BoolP("add-slash", "f", false, "Append / to each request")
 	cmdDir.Flags().BoolP("discover-backup", "d", false, "Upon finding a file search for backup files")
 	cmdDir.Flags().IntSlice("exclude-length", []int{}, "exclude the following content length (completely ignores the status). Supply multiple times to exclude multiple sizes.")
+	cmdDir.Flags().Int("exclude-length-range", 0, "Provide a numerical range of content lengths to ignore (e.g. 1000 +/- the base). Use exclude-length to provide the base lengths.")
+
 
 	cmdDir.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		configureGlobalOptions()

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -19,6 +19,7 @@ type OptionsDir struct {
 	NoStatus                   bool
 	DiscoverBackup             bool
 	ExcludeLength              []int
+	ExcludeLengthRange         int
 }
 
 // NewOptionsDir returns a new initialized OptionsDir


### PR DESCRIPTION
Provides an additional argument to be used with `--exclude-length` in order to exclude a range of content lengths. Occasionally, I've had content length enumeration come back with many slight differences due to cookies, response body caching values, UUIDs randomly generated on each request, that I want to bulk exclude, such as:
 
```
1905
2200
2199
2197
```

However, I don't want to specify every single one of these in the `--exclude-length` argument.

Instead, I added `--exclude-length-range` which can be used to provide a base value which will setup a Min and Max off of the base `--exclude-length` value.

For example, if you had an incoming content length of 2000 that you want to exclude all content lengths from 1400 - 2600, you would setup the gobuster arguments as the following:

`gobuster dir -u <url> --exclude-length 2000 --exclude-length-range 600`

This should also work alongside the `-b` arguments to combo block lengths and status codes