### PR TITLE
Added "wordlist-offset" flag to resume from specific position in the wordlist

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -88,6 +88,20 @@ func parseGlobalOptions() (*libgobuster.Options, error) {
 		return nil, fmt.Errorf("wordlist file %q does not exist: %w", globalopts.Wordlist, err2)
 	}
 
+	offset, err := rootCmd.Flags().GetInt("wordlist-offset")
+	if err != nil {
+		return nil, fmt.Errorf("invalid value for wordlist-offset: %w", err)
+	}
+
+	if offset < 0 {
+		return nil, fmt.Errorf("wordlist-offset must be bigger or equal to 0")
+	}
+	globalopts.WordlistOffset = offset
+
+	if globalopts.Wordlist == "-" && globalopts.WordlistOffset > 0 {
+		return nil, fmt.Errorf("wordlist-offset is not supported when reading from STDIN")
+	}
+
 	globalopts.PatternFile, err = rootCmd.Flags().GetString("pattern")
 	if err != nil {
 		return nil, fmt.Errorf("invalid value for pattern: %w", err)
@@ -163,6 +177,7 @@ func init() {
 	rootCmd.PersistentFlags().DurationP("delay", "", 0, "Time each thread waits between requests (e.g. 1500ms)")
 	rootCmd.PersistentFlags().IntP("threads", "t", 10, "Number of concurrent threads")
 	rootCmd.PersistentFlags().StringP("wordlist", "w", "", "Path to the wordlist")
+	rootCmd.PersistentFlags().IntP("wordlist-offset", "", 0, "Resume from a given position in the wordlist (defaults to 0)")
 	rootCmd.PersistentFlags().StringP("output", "o", "", "Output file to write results to (defaults to stdout)")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output (errors)")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Don't print the banner and other noise")

--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -131,6 +131,9 @@ func Gobuster(ctx context.Context, opts *libgobuster.Options, plugin libgobuster
 		fmt.Println(c)
 		fmt.Println(ruler)
 		gobuster.LogInfo.Printf("Starting gobuster in %s mode", plugin.Name())
+		if opts.WordlistOffset > 0 {
+			gobuster.LogInfo.Printf("Skipping the first %d elements...", opts.WordlistOffset)
+		}
 		fmt.Println(ruler)
 	}
 

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -6,6 +6,7 @@ import "time"
 type Options struct {
 	Threads        int
 	Wordlist       string
+	WordlistOffset int
 	PatternFile    string
 	Patterns       []string
 	OutputFilename string


### PR DESCRIPTION
## Summary
Added a new feature, that allows users to resume from a specific position in the wordlist file by specifying the `--wordlist-offset <int>` flag. This is a very non-intrusive and easy-to-use state-resuming mechanism. **When using huge wordlists, this feature is simply a must.**

## Motivation
While using Gobuster, I encountered a problem where I had to interrupt it to add filters. When I restarted the tool, it had to start from the beginning of the wordlist file, resulting in tedious re-iterations of previously tested URLs. This made it inefficient and time-consuming.

In some more advanced brute-force programs, the user can continue from an ongoing state (which happens a lot - from forgetting a flag to sudden internet interruptions). For example, [epi052/feroxbuster](https://github.com/epi052/feroxbuster) creates a state file on the current directory and a willing user may set `--resume-from <state-file>` and save time by not re-iterating the same elements repeatedly. I find this mechanism rather cumbersome because it may create many state files (this feature is on by default)


## Changes Made
To address this problem, I added a new flag, `--wordlist-offset <n: int>`, to the tool's command-line interface. This flag allows users to skip the first `n` elements in the wordlist file, thereby resuming the brute-force from that point. I also added a check for where the `n` is larger than the number of elements.

## Usage
#### Command:
```bash
gobuster dir -u http://example.com/ -w wordlist.txt --wordlist-offset 400
```
#### Output:
```
===============================================================
Gobuster v3.5
===============================================================
[+] Method:                  GET
[+] Wordlist:                .\wordlist.txt
[+] Negative Status codes:   404
[+] User Agent:              gobuster/3.5
[+] Timeout:                 10s
===============================================================
2023/03/18 00:34:26 Starting gobuster in directory enumeration mode
2023/03/18 00:34:26 Skipping the first 400 elements...
===============================================================
Progress: 401 / 156211 (0.25%)
```

## Additional Information
I have tested this feature thoroughly on my local machine, and it works as expected.

I believe this feature will greatly enhance the tool's functionality and usability, and I hope it will be considered for inclusion in the next release.