### PR TITLE
GoReleaser action deprecated argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/OJ/gobuster/blob/c3fed5e2f2c4d4b1f3b2643a55d8f0692f49e95d/.github/workflows/release.yml#L30

*--rm-dist* argument has been deprecated in favor of --clean. ( since 2023-01-17 (v1.15.0 of GoReleaser). Learn more [here](https://goreleaser.com/deprecations/#-rm-dist)