### PR TITLE
Update Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OJ/gobuster/v3
 
-go 1.19
+go 1.21
 
 require (
 	github.com/fatih/color v1.15.0


### PR DESCRIPTION
The jump to 1.21 makes things a tad faster, without breaking anything (all tests passed etc.)