### PR TITLE
Don't print escape sequence when no-color flag is set

### DIFF
--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -36,7 +36,11 @@ func resultWorker(g *libgobuster.Gobuster, filename string, wg *sync.WaitGroup) 
 		}
 		if s != "" {
 			s = strings.TrimSpace(s)
-			_, _ = fmt.Printf("%s%s\n", TERMINAL_CLEAR_LINE, s)
+			if(g.Opts.NoColor){
+				_, _ = fmt.Printf("\r%s\n", s)
+			} else {
+				_, _ = fmt.Printf("%s%s\n", TERMINAL_CLEAR_LINE, s)
+			}
 			if f != nil {
 				err = writeToFile(f, s)
 				if err != nil {

--- a/cli/options.go
+++ b/cli/options.go
@@ -232,6 +232,7 @@ func ParseGlobalOptions(c *cli.Context) (libgobuster.Options, error) {
 	}
 
 	if c.Bool("no-color") {
+		opts.NoColor = true
 		color.NoColor = true
 	}
 

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -14,6 +14,7 @@ type Options struct {
 	NoStatus       bool
 	NoProgress     bool
 	NoError        bool
+	NoColor        bool
 	Quiet          bool
 	Delay          time.Duration
 }


### PR DESCRIPTION
Gobuster prints a terminal escape sequence `"\r\x1b[2K"` at the start of each output finding to clear the terminal line, even when there is no TTY. The escape codes can cause trouble when piped to some CLI tools.

This PR prevents the escape code from being printed when the 'no-color' flag is set. Here's how the output differs:

```
# ./gobuster dns --quiet -w /tmp/wl  --do google.com -i | hexdump -C
00000000  0d 1b 5b 32 4b 77 77 77  2e 67 6f 6f 67 6c 65 2e  |..[2Kwww.google.|
00000010  63 6f 6d 20 49 50 73 3a  20 32 36 30 37 3a 66 38  |com IPs: 2607:f8|
00000020  62 30 3a 34 30 30 35 3a  38 31 33 3a 3a 32 30 30  |b0:4005:813::200|
00000030  34 2c 31 34 32 2e 32 35  30 2e 31 38 39 2e 31 36  |4,142.250.189.16|
00000040  34 0a 0d 1b 5b 32 4b 73  69 74 65 73 2e 67 6f 6f  |4...[2Ksites.goo|
00000050  67 6c 65 2e 63 6f 6d 20  49 50 73 3a 20 32 36 30  |gle.com IPs: 260|
00000060  37 3a 66 38 62 30 3a 34  30 30 35 3a 38 30 32 3a  |7:f8b0:4005:802:|
00000070  3a 32 30 30 65 2c 31 34  32 2e 32 35 31 2e 34 36  |:200e,142.251.46|
00000080  2e 32 33 38 0a 0d 1b 5b  32 4b 66 65 65 64 73 2e  |.238...[2Kfeeds.|
00000090  67 6f 6f 67 6c 65 2e 63  6f 6d 20 49 50 73 3a 20  |google.com IPs: |
000000a0  31 30 38 2e 31 37 30 2e  32 31 37 2e 31 36 30 0a  |108.170.217.160.|
000000b0
# ./gobuster dns --no-color --quiet -w /tmp/wl  --do google.com -i | hexdump -C
00000000  0d 77 77 77 2e 67 6f 6f  67 6c 65 2e 63 6f 6d 20  |.www.google.com |
00000010  49 50 73 3a 20 32 36 30  37 3a 66 38 62 30 3a 34  |IPs: 2607:f8b0:4|
00000020  30 30 35 3a 38 30 31 3a  3a 32 30 30 34 2c 31 34  |005:801::2004,14|
00000030  32 2e 32 35 30 2e 37 32  2e 31 39 36 0a 0d 73 69  |2.250.72.196..si|
00000040  74 65 73 2e 67 6f 6f 67  6c 65 2e 63 6f 6d 20 49  |tes.google.com I|
00000050  50 73 3a 20 32 36 30 37  3a 66 38 62 30 3a 34 30  |Ps: 2607:f8b0:40|
00000060  30 35 3a 38 30 65 3a 3a  32 30 30 65 2c 31 34 32  |05:80e::200e,142|
00000070  2e 32 35 30 2e 31 38 39  2e 31 37 34 0a 0d 66 65  |.250.189.174..fe|
00000080  65 64 73 2e 67 6f 6f 67  6c 65 2e 63 6f 6d 20 49  |eds.google.com I|
00000090  50 73 3a 20 31 30 38 2e  31 37 30 2e 32 31 37 2e  |Ps: 108.170.217.|
000000a0  31 36 30 0a                                       |160.|
000000a4

```