### PR TITLE
Fix "local error: tls: no renegotiation" for self-signed certs

### DIFF
--- a/libgobuster/http.go
+++ b/libgobuster/http.go
@@ -70,6 +70,7 @@ func NewHTTPClient(opt *HTTPOptions) (*HTTPClient, error) {
 
 	tlsConfig := tls.Config{
 		InsecureSkipVerify: opt.NoTLSValidation,
+		Renegotiation:      tls.RenegotiateOnceAsClient,
 		// enable TLS1.0 and TLS1.1 support
 		MinVersion: tls.VersionTLS10,
 	}


### PR DESCRIPTION
Some servers with self-signed certs response cause a "local error: tls: no renegotiation" error. To fix, I added "Renegotiation: tls.RenegotiateOnceAsClient" to the TLS config per this solution:

https://stackoverflow.com/questions/57420833/tls-no-renegotiation-error-on-http-request

Seems to fix the problem.