### PR TITLE
addressing: error strings should not end with punctuation or newlines…

### DIFF
--- a/cli/vhost/vhost.go
+++ b/cli/vhost/vhost.go
@@ -70,7 +70,7 @@ func run(c *cli.Context) error {
 	if !force &&
 		(strings.HasPrefix(pluginOpts.Proxy, "http://") || strings.HasPrefix(pluginOpts.Proxy, "https://")) &&
 		strings.HasPrefix(pluginOpts.URL, "http://") {
-		return fmt.Errorf("VHOST mode does not work with a http proxy when using plain text http urls as golang strictly adheres to the http standard. This results in always sending the requests to the IP of the VHOST domain instead of the specified target. See https://github.com/golang/go/issues/30775 for example. You need to either disable the proxy, use a https based url or use the --force switch to continue. When using --force you may need to do some rewrites in your proxy to get the expected result.")
+		return fmt.Errorf("VHOST mode does not work with a http proxy when using plain text http urls as golang strictly adheres to the http standard. This results in always sending the requests to the IP of the VHOST domain instead of the specified target. See https://github.com/golang/go/issues/30775 for example. You need to either disable the proxy, use a https based url or use the --force switch to continue. When using --force you may need to do some rewrites in your proxy to get the expected result")
 	}
 
 	log := libgobuster.NewLogger(globalOpts.Debug)


### PR DESCRIPTION
Hey! While reading through the code I found this simple issue and started to contribute!!!
