### PR TITLE
Add StatusCode vHost Response Filtering

### DIFF
--- a/cli/cmd/vhost.go
+++ b/cli/cmd/vhost.go
@@ -103,12 +103,8 @@ func parseVhostOptions() (*libgobuster.Options, *gobustervhost.OptionsVhost, err
 	pluginOpts.StatusCodesBlacklistParsed = ret3
 
 	if pluginOpts.StatusCodes != "" && pluginOpts.StatusCodesBlacklist != "" {
-		return nil, nil, fmt.Errorf("status-codes (%q) and status-codes-blacklist (%q) are both set - please set only one. status-codes-blacklist is set by default so you might want to disable it by supplying an empty string.",
+		return nil, nil, fmt.Errorf("status-codes (%q) and status-codes-blacklist (%q) are both set - please set only one. status-codes-blacklist is set by default so you might want to disable it by supplying an empty string",
 			pluginOpts.StatusCodes, pluginOpts.StatusCodesBlacklist)
-	}
-
-	if pluginOpts.StatusCodes == "" && pluginOpts.StatusCodesBlacklist == "" {
-		return nil, nil, fmt.Errorf("status-codes and status-codes-blacklist are both not set, please set one")
 	}
 
 	return globalopts, pluginOpts, nil
@@ -125,7 +121,7 @@ func init() {
 		log.Fatalf("%v", err)
 	}
 	cmdVhost.Flags().StringP("status-codes", "s", "", "Positive status codes (will be overwritten with status-codes-blacklist if set). Can also handle ranges like 200,300-400,404.")
-	cmdVhost.Flags().StringP("status-codes-blacklist", "b", "404", "Negative status codes (will override status-codes if set). Can also handle ranges like 200,300-400,404.")
+	cmdVhost.Flags().StringP("status-codes-blacklist", "b", "", "Negative status codes (will override status-codes if set). Can also handle ranges like 200,300-400,404.")
 	cmdVhost.Flags().BoolP("append-domain", "", false, "Append main domain from URL to words from wordlist. Otherwise the fully qualified domains need to be specified in the wordlist.")
 	cmdVhost.Flags().String("exclude-length", "", "exclude the following content lengths (completely ignores the status). You can separate multiple lengths by comma and it also supports ranges like 203-206")
 	cmdVhost.Flags().String("domain", "", "the domain to append when using an IP address as URL. If left empty and you specify a domain based URL the hostname from the URL is extracted")

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -163,8 +163,6 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 				if !v.options.StatusCodesParsed.Contains(statusCode) {
 					return nil
 				}
-			} else {
-				return fmt.Errorf("StatusCodes and StatusCodesBlacklist are both not set which should not happen")
 			}
 		}
 		progress.ResultChan <- Result{

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -155,6 +155,17 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 		resultStatus := false
 		if found {
 			resultStatus = true
+			if v.options.StatusCodesBlacklistParsed.Length() > 0 {
+				if v.options.StatusCodesBlacklistParsed.Contains(statusCode) {
+					return nil
+				}
+			} else if v.options.StatusCodesParsed.Length() > 0 {
+				if !v.options.StatusCodesParsed.Contains(statusCode) {
+					return nil
+				}
+			} else {
+				return fmt.Errorf("StatusCodes and StatusCodesBlacklist are both not set which should not happen")
+			}
 		}
 		progress.ResultChan <- Result{
 			Found:      resultStatus,
@@ -205,6 +216,16 @@ func (v *GobusterVhost) GetConfigString() (string, error) {
 
 	if v.globalopts.PatternFile != "" {
 		if _, err := fmt.Fprintf(tw, "[+] Patterns:\t%s (%d entries)\n", v.globalopts.PatternFile, len(v.globalopts.Patterns)); err != nil {
+			return "", err
+		}
+	}
+
+	if o.StatusCodesBlacklistParsed.Length() > 0 {
+		if _, err := fmt.Fprintf(tw, "[+] Negative Status codes:\t%s\n", o.StatusCodesBlacklistParsed.Stringify()); err != nil {
+			return "", err
+		}
+	} else if o.StatusCodesParsed.Length() > 0 {
+		if _, err := fmt.Fprintf(tw, "[+] Status codes:\t%s\n", o.StatusCodesParsed.Stringify()); err != nil {
 			return "", err
 		}
 	}

--- a/gobustervhost/options.go
+++ b/gobustervhost/options.go
@@ -7,6 +7,10 @@ import (
 // OptionsVhost is the struct to hold all options for this plugin
 type OptionsVhost struct {
 	libgobuster.HTTPOptions
+	StatusCodes                string
+	StatusCodesParsed          libgobuster.Set[int]
+	StatusCodesBlacklist       string
+	StatusCodesBlacklistParsed libgobuster.Set[int]
 	AppendDomain        bool
 	ExcludeLength       string
 	ExcludeLengthParsed libgobuster.Set[int]
@@ -16,6 +20,8 @@ type OptionsVhost struct {
 // NewOptionsVhost returns a new initialized OptionsVhost
 func NewOptionsVhost() *OptionsVhost {
 	return &OptionsVhost{
+		StatusCodesParsed:          libgobuster.NewSet[int](),
+		StatusCodesBlacklistParsed: libgobuster.NewSet[int](),
 		ExcludeLengthParsed: libgobuster.NewSet[int](),
 	}
 }


### PR DESCRIPTION
Adds the ability to whitelist or blacklist HTTP StatusCodes inside the vHost module in a manner similar to the dir module