### PR TITLE
Exclude status code in VHOST

### DIFF
--- a/cli/cmd/vhost.go
+++ b/cli/cmd/vhost.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/OJ/gobuster/v3/cli"
 	"github.com/OJ/gobuster/v3/gobustervhost"
@@ -12,6 +13,14 @@ import (
 
 // nolint:gochecknoglobals
 var cmdVhost *cobra.Command
+
+func parseStatusCode(s string) (int, error) {
+    num, err := strconv.Atoi(s)
+    if err != nil {
+        return 0, err
+    }
+    return num, nil
+}
 
 func runVhost(cmd *cobra.Command, args []string) error {
 	globalopts, pluginopts, err := parseVhostOptions()
@@ -80,6 +89,17 @@ func parseVhostOptions() (*libgobuster.Options, *gobustervhost.OptionsVhost, err
 		return nil, nil, fmt.Errorf("invalid value for domain: %w", err)
 	}
 
+
+	pluginOpts.ExcludeCode, err = cmdVhost.Flags().GetString("exclude-code")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for exclude-code: %w", err)
+	}
+	code, err := parseStatusCode(pluginOpts.ExcludeCode)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for exclude-code: %w", err)
+	}
+	pluginOpts.ExcludeCodeParsed = code
+
 	return globalopts, pluginOpts, nil
 }
 
@@ -96,6 +116,7 @@ func init() {
 	cmdVhost.Flags().BoolP("append-domain", "", false, "Append main domain from URL to words from wordlist. Otherwise the fully qualified domains need to be specified in the wordlist.")
 	cmdVhost.Flags().String("exclude-length", "", "exclude the following content lengths (completely ignores the status). You can separate multiple lengths by comma and it also supports ranges like 203-206")
 	cmdVhost.Flags().String("domain", "", "the domain to append when using an IP address as URL. If left empty and you specify a domain based URL the hostname from the URL is extracted")
+	cmdVhost.Flags().String("exclude-code", "", "exclude the following status code")
 
 	cmdVhost.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		configureGlobalOptions()

--- a/cli/cmd/vhost.go
+++ b/cli/cmd/vhost.go
@@ -15,6 +15,9 @@ import (
 var cmdVhost *cobra.Command
 
 func parseStatusCode(s string) (int, error) {
+	if s == "" {
+		return 1, nil
+	}
     num, err := strconv.Atoi(s)
     if err != nil {
         return 0, err

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -148,10 +148,10 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 		break
 	}
 
-	// subdomain must not match default vhost and non existent vhost
-	// or verbose mode is enabled
 	found := body != nil && !bytes.Equal(body, v.normalBody) && !bytes.Equal(body, v.abnormalBody)
-	if (found && !v.options.ExcludeLengthParsed.Contains(int(size))) || v.globalopts.Verbose {
+	code := false
+	if (found && v.options.ExcludeCodeParsed != statusCode) || v.globalopts.Verbose {
+		code = true
 		resultStatus := false
 		if found {
 			resultStatus = true
@@ -164,6 +164,25 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 			Header:     header,
 		}
 	}
+	// subdomain must not match default vhost and non existent vhost
+	// or verbose mode is enabled
+	if (found && !v.options.ExcludeLengthParsed.Contains(int(size))) || v.globalopts.Verbose {
+		resultStatus := false
+		if found {
+			resultStatus = true
+		}
+		if(code || v.globalopts.Verbose){
+		progress.ResultChan <- Result{
+			Found:      resultStatus,
+			Vhost:      subdomain,
+			StatusCode: statusCode,
+			Size:       size,
+			Header:     header,
+		}
+	}
+	}
+
+
 	return nil
 }
 

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -25,6 +25,7 @@ type GobusterVhost struct {
 	abnormalBody []byte
 }
 
+
 // NewGobusterVhost creates a new initialized GobusterDir
 func NewGobusterVhost(globalopts *libgobuster.Options, opts *OptionsVhost) (*GobusterVhost, error) {
 	if globalopts == nil {
@@ -150,18 +151,11 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 
 	found := body != nil && !bytes.Equal(body, v.normalBody) && !bytes.Equal(body, v.abnormalBody)
 	code := false
+	show := false
 	if (found && v.options.ExcludeCodeParsed != statusCode) || v.globalopts.Verbose {
 		code = true
-		resultStatus := false
-		if found {
-			resultStatus = true
-		}
-		progress.ResultChan <- Result{
-			Found:      resultStatus,
-			Vhost:      subdomain,
-			StatusCode: statusCode,
-			Size:       size,
-			Header:     header,
+		if v.options.ExcludeCodeParsed != 1{ //caso seja diferente, é pq tá ativo entao ele manda a req 
+			show = true
 		}
 	}
 	// subdomain must not match default vhost and non existent vhost
@@ -172,6 +166,7 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 			resultStatus = true
 		}
 		if(code || v.globalopts.Verbose){
+		show = false
 		progress.ResultChan <- Result{
 			Found:      resultStatus,
 			Vhost:      subdomain,
@@ -180,7 +175,18 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 			Header:     header,
 		}
 	}
+	if show{
+		progress.ResultChan <- Result{
+			Found:      resultStatus,
+			Vhost:      subdomain,
+			StatusCode: statusCode,
+			Size:       size,
+			Header:     header,
+		}
 	}
+
+
+}
 
 
 	return nil

--- a/gobustervhost/options.go
+++ b/gobustervhost/options.go
@@ -11,6 +11,8 @@ type OptionsVhost struct {
 	ExcludeLength       string
 	ExcludeLengthParsed libgobuster.Set[int]
 	Domain              string
+	ExcludeCode string
+	ExcludeCodeParsed int
 }
 
 // NewOptionsVhost returns a new initialized OptionsVhost


### PR DESCRIPTION
I created a code that will filter a certain status code passed to the vhost.
![image](https://github.com/user-attachments/assets/ecf73793-2d41-42a1-be3c-848b3f425e8e)

`./gobuster vhost -u http://saori.hc/ -t 50 -w /usr/share/wordlists/subdomains.txt --append-domain --exclude-length 300-310 --exclude-code 301`

If I pass `--exclude-code 301` as an example it will not return any response that has this status code.

![image](https://github.com/user-attachments/assets/a8b696e3-925e-4b16-9685-f2e0ad7ace07)

Example with `--exclude-code 400`