### PR TITLE
Add exclude-hostname-length flag to dynamically adjust exclude-length

### DIFF
--- a/cli/cmd/vhost.go
+++ b/cli/cmd/vhost.go
@@ -80,6 +80,11 @@ func parseVhostOptions() (*libgobuster.Options, *gobustervhost.OptionsVhost, err
 		return nil, nil, fmt.Errorf("invalid value for domain: %w", err)
 	}
 
+	pluginOpts.ExcludeHostnameLength, err = cmdVhost.Flags().GetBool("exclude-hostname-length")
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid value for exclude-hostname-length: %w", err)
+	}
+
 	return globalopts, pluginOpts, nil
 }
 
@@ -95,6 +100,7 @@ func init() {
 	}
 	cmdVhost.Flags().BoolP("append-domain", "", false, "Append main domain from URL to words from wordlist. Otherwise the fully qualified domains need to be specified in the wordlist.")
 	cmdVhost.Flags().String("exclude-length", "", "exclude the following content lengths (completely ignores the status). You can separate multiple lengths by comma and it also supports ranges like 203-206")
+	cmdVhost.Flags().BoolP("exclude-hostname-length", "d", false, "Automatically adjust exclude-length based on dynamic hostname length in responses")
 	cmdVhost.Flags().String("domain", "", "the domain to append when using an IP address as URL. If left empty and you specify a domain based URL the hostname from the URL is extracted")
 
 	cmdVhost.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/gobustervhost/options.go
+++ b/gobustervhost/options.go
@@ -7,10 +7,11 @@ import (
 // OptionsVhost is the struct to hold all options for this plugin
 type OptionsVhost struct {
 	libgobuster.HTTPOptions
-	AppendDomain        bool
-	ExcludeLength       string
-	ExcludeLengthParsed libgobuster.Set[int]
-	Domain              string
+	AppendDomain          bool
+	ExcludeLength         string
+	ExcludeLengthParsed   libgobuster.Set[int]
+	Domain                string
+	ExcludeHostnameLength bool
 }
 
 // NewOptionsVhost returns a new initialized OptionsVhost


### PR DESCRIPTION
This PR introduces the *--exclude-hostname-length* flag for the vhost option to Gobuster, allowing users to dynamically adjust the *exclude-length* value based on the length of the hostname (fuzzing word) in the response. This feature is useful for cases where webservers return the subdomain or hostname in the response, causing the response length to vary.
 
 ## Key Changes:
- New vhost flag *--exclude-hostname-length*
- Simple change in exclude length control logic: `if (found && !v.options.ExcludeLengthParsed.Contains(int(size)-wordLength))` (subtracts the hostname length from the returned size, always matching the static size entered by the user)

## PoC
In the following screenshot, the response size is variable because of the subdomain included in the response. The problem could be bypassed by submitting a range but it would be less precise.

![gobuster_no_hostname_exclude](https://github.com/user-attachments/assets/156de493-fd8d-4bb3-80b5-f91a41e74787)

By submitting the static size to *--exclude-length* (283 in this case) and the *--exclude-hostname-length* flag, Gobuster skips all the previous false positives.

![gobuster_hostname_exclude](https://github.com/user-attachments/assets/36ea6717-9444-46ce-a8a7-f5972e8fe48e)

