### PR TITLE
Fix progress with patterns and backup discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,25 +185,26 @@ USAGE:
    gobuster dns [command options] [arguments...]
 
 OPTIONS:
-   --domain value, --do value           The target domain
-   --show-ips, -i                       Show IP addresses of found domains (default: false)
-   --check-cname, -c                    Also check CNAME records (default: false)
-   --timeout value, --to value          DNS resolver timeout (default: 1s)
-   --wildcard, --wc                     Force continued operation when wildcard found (default: false)
-   --no-fqdn, --nf                      Do not automatically add a trailing dot to the domain, so the resolver uses the DNS search domain (default: false)
-   --resolver value                     Use custom DNS server (format server.com or server.com:port)
-   --wordlist value, -w value           Path to the wordlist. Set to - to use STDIN.
-   --delay value, -d value              Time each thread waits between requests (e.g. 1500ms) (default: 0s)
-   --threads value, -t value            Number of concurrent threads (default: 10)
-   --wordlist-offset value, --wo value  Resume from a given position in the wordlist (default: 0)
-   --output value, -o value             Output file to write results to (defaults to stdout)
-   --quiet, -q                          Don't print the banner and other noise (default: false)
-   --no-progress, --np                  Don't display progress (default: false)
-   --no-error, --ne                     Don't display errors (default: false)
-   --pattern value, -p value            File containing replacement patterns
-   --no-color, --nc                     Disable color output (default: false)
-   --debug                              enable debug output (default: false)
-   --help, -h                           show help
+   --domain value, --do value            The target domain
+   --show-ips, -i                        Show IP addresses of found domains (default: false)
+   --check-cname, -c                     Also check CNAME records (default: false)
+   --timeout value, --to value           DNS resolver timeout (default: 1s)
+   --wildcard, --wc                      Force continued operation when wildcard found (default: false)
+   --no-fqdn, --nf                       Do not automatically add a trailing dot to the domain, so the resolver uses the DNS search domain (default: false)
+   --resolver value                      Use custom DNS server (format server.com or server.com:port)
+   --wordlist value, -w value            Path to the wordlist. Set to - to use STDIN.
+   --delay value, -d value               Time each thread waits between requests (e.g. 1500ms) (default: 0s)
+   --threads value, -t value             Number of concurrent threads (default: 10)
+   --wordlist-offset value, --wo value   Resume from a given position in the wordlist (default: 0)
+   --output value, -o value              Output file to write results to (defaults to stdout)
+   --quiet, -q                           Don't print the banner and other noise (default: false)
+   --no-progress, --np                   Don't display progress (default: false)
+   --no-error, --ne                      Don't display errors (default: false)
+   --pattern value, -p value             File containing replacement patterns
+   --discover-pattern value, --pd value  File containing replacement patterns applied to successful guesses
+   --no-color, --nc                      Disable color output (default: false)
+   --debug                               enable debug output (default: false)
+   --help, -h                            show help
 ```
 
 ### Examples
@@ -401,6 +402,7 @@ OPTIONS:
    --no-progress, --np                                      Don't display progress (default: false)
    --no-error, --ne                                         Don't display errors (default: false)
    --pattern value, -p value                                File containing replacement patterns
+   --discover-pattern value, --pd value                     File containing replacement patterns applied to successful guesses
    --no-color, --nc                                         Disable color output (default: false)
    --debug                                                  enable debug output (default: false)
    --status-codes value, -s value                           Positive status codes (will be overwritten with status-codes-blacklist if set). Can also handle ranges like 200,300-400,404
@@ -589,6 +591,7 @@ OPTIONS:
    --no-progress, --np                                      Don't display progress (default: false)
    --no-error, --ne                                         Don't display errors (default: false)
    --pattern value, -p value                                File containing replacement patterns
+   --discover-pattern value, --pd value                     File containing replacement patterns applied to successful guesses
    --no-color, --nc                                         Disable color output (default: false)
    --debug                                                  enable debug output (default: false)
    --append-domain, --ad                                    Append main domain from URL to words from wordlist. Otherwise the fully qualified domains need to be specified in the wordlist. (default: false)
@@ -669,6 +672,7 @@ OPTIONS:
    --no-progress, --np                                      Don't display progress (default: false)
    --no-error, --ne                                         Don't display errors (default: false)
    --pattern value, -p value                                File containing replacement patterns
+   --discover-pattern value, --pd value                     File containing replacement patterns applied to successful guesses
    --no-color, --nc                                         Disable color output (default: false)
    --debug                                                  enable debug output (default: false)
    --exclude-statuscodes value, -b value                    Excluded status codes. Can also handle ranges like 200,300-400,404.
@@ -706,6 +710,7 @@ OPTIONS:
    --no-progress, --np                               Don't display progress (default: false)
    --no-error, --ne                                  Don't display errors (default: false)
    --pattern value, -p value                         File containing replacement patterns
+   --discover-pattern value, --pd value              File containing replacement patterns applied to successful guesses
    --no-color, --nc                                  Disable color output (default: false)
    --debug                                           enable debug output (default: false)
    --useragent value, -a value                       Set the User-Agent string (default: "gobuster/3.7")
@@ -751,6 +756,7 @@ OPTIONS:
    --no-progress, --np                               Don't display progress (default: false)
    --no-error, --ne                                  Don't display errors (default: false)
    --pattern value, -p value                         File containing replacement patterns
+   --discover-pattern value, --pd value              File containing replacement patterns applied to successful guesses
    --no-color, --nc                                  Disable color output (default: false)
    --debug                                           enable debug output (default: false)
    --useragent value, -a value                       Set the User-Agent string (default: "gobuster/3.7")
@@ -785,20 +791,21 @@ USAGE:
    gobuster tftp [command options] [arguments...]
 
 OPTIONS:
-   --server value, -s value             The target TFTP server
-   --timeout value, --to value          TFTP timeout (default: 1s)
-   --wordlist value, -w value           Path to the wordlist. Set to - to use STDIN.
-   --delay value, -d value              Time each thread waits between requests (e.g. 1500ms) (default: 0s)
-   --threads value, -t value            Number of concurrent threads (default: 10)
-   --wordlist-offset value, --wo value  Resume from a given position in the wordlist (default: 0)
-   --output value, -o value             Output file to write results to (defaults to stdout)
-   --quiet, -q                          Don't print the banner and other noise (default: false)
-   --no-progress, --np                  Don't display progress (default: false)
-   --no-error, --ne                     Don't display errors (default: false)
-   --pattern value, -p value            File containing replacement patterns
-   --no-color, --nc                     Disable color output (default: false)
-   --debug                              enable debug output (default: false)
-   --help, -h                           show help
+   --server value, -s value              The target TFTP server
+   --timeout value, --to value           TFTP timeout (default: 1s)
+   --wordlist value, -w value            Path to the wordlist. Set to - to use STDIN.
+   --delay value, -d value               Time each thread waits between requests (e.g. 1500ms) (default: 0s)
+   --threads value, -t value             Number of concurrent threads (default: 10)
+   --wordlist-offset value, --wo value   Resume from a given position in the wordlist (default: 0)
+   --output value, -o value              Output file to write results to (defaults to stdout)
+   --quiet, -q                           Don't print the banner and other noise (default: false)
+   --no-progress, --np                   Don't display progress (default: false)
+   --no-error, --ne                      Don't display errors (default: false)
+   --pattern value, -p value             File containing replacement patterns
+   --discover-pattern value, --pd value  File containing replacement patterns applied to successful guesses
+   --no-color, --nc                      Disable color output (default: false)
+   --debug                               enable debug output (default: false)
+   --help, -h                            show help
 ```
 
 ### Examples
@@ -823,6 +830,7 @@ Note: If the `-w` option is specified at the same time as piping from STDIN, an 
 You can supply pattern files that will be applied to every word from the wordlist.
 Just place the string `{GOBUSTER}` in it and this will be replaced with the word.
 This feature is also handy in s3 mode to pre- or postfix certain patterns.
+When supplying patterns, words from the wordlist will not be tried by themselves. If you wish to have patterns and plain words from the wordlist, place `{GOBUSTER}` on a line by itself in the pattern file.
 
 **Caution:** Using a big pattern file can cause a lot of request as every pattern is applied to every word in the wordlist.
 

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ OPTIONS:
    --no-status, -n                                          Don't print status codes (default: false)
    --hide-length, --hl                                      Hide the length of the body in the output (default: false)
    --add-slash, -f                                          Append / to each request (default: false)
-   --discover-backup, --db                                  Also search for backup files by appending multiple backup extensions (default: false)
+   --discover-backup, --db                                  Upon finding a file search for backup files by appending multiple backup extensions (default: false)
    --exclude-length value, --xl value                       exclude the following content lengths (completely ignores the status). You can separate multiple lengths by comma and it also supports ranges like 203-206
    --help, -h                                               show help
 ```

--- a/cli/dir/dir.go
+++ b/cli/dir/dir.go
@@ -33,7 +33,7 @@ func getFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "no-status", Aliases: []string{"n"}, Value: false, Usage: "Don't print status codes"},
 		&cli.BoolFlag{Name: "hide-length", Aliases: []string{"hl"}, Value: false, Usage: "Hide the length of the body in the output"},
 		&cli.BoolFlag{Name: "add-slash", Aliases: []string{"f"}, Value: false, Usage: "Append / to each request"},
-		&cli.BoolFlag{Name: "discover-backup", Aliases: []string{"db"}, Value: false, Usage: "Also search for backup files by appending multiple backup extensions"},
+		&cli.BoolFlag{Name: "discover-backup", Aliases: []string{"db"}, Value: false, Usage: "Upon finding a file search for backup files by appending multiple backup extensions"},
 		&cli.StringFlag{Name: "exclude-length", Aliases: []string{"xl"}, Usage: "exclude the following content lengths (completely ignores the status). You can separate multiple lengths by comma and it also supports ranges like 203-206"},
 	}...)
 	return flags

--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -93,14 +93,8 @@ func messageWorker(g *libgobuster.Gobuster, wg *sync.WaitGroup) {
 func printProgress(g *libgobuster.Gobuster) {
 	requestsIssued := g.Progress.RequestsIssued()
 	requestsExpected := g.Progress.RequestsExpected()
-	if g.Opts.Wordlist == "-" {
-		s := fmt.Sprintf("%sProgress: %d", TERMINAL_CLEAR_LINE, requestsIssued)
-		_, _ = fmt.Fprint(os.Stderr, s)
-		// only print status if we already read in the wordlist
-	} else if requestsExpected > 0 {
-		s := fmt.Sprintf("%sProgress: %d / %d (%3.2f%%)", TERMINAL_CLEAR_LINE, requestsIssued, requestsExpected, float32(requestsIssued)*100.0/float32(requestsExpected))
-		_, _ = fmt.Fprint(os.Stderr, s)
-	}
+	s := fmt.Sprintf("%sProgress: %d / %d (%3.2f%%)", TERMINAL_CLEAR_LINE, requestsIssued, requestsExpected, float32(requestsIssued)*100.0/float32(requestsExpected))
+	_, _ = fmt.Fprint(os.Stderr, s)
 }
 
 // progressWorker outputs the progress every tick. It will stop once cancel() is called

--- a/cli/options.go
+++ b/cli/options.go
@@ -213,7 +213,7 @@ func GlobalOptions() []cli.Flag {
 		&cli.BoolFlag{Name: "no-progress", Aliases: []string{"np"}, Value: false, Usage: "Don't display progress"},
 		&cli.BoolFlag{Name: "no-error", Aliases: []string{"ne"}, Value: false, Usage: "Don't display errors"},
 		&cli.StringFlag{Name: "pattern", Aliases: []string{"p"}, Usage: "File containing replacement patterns"},
-		&cli.StringFlag{Name: "discover-pattern", Aliases: []string{"pd"}, Usage: "File containing replacement patterns for successful guesses"},
+		&cli.StringFlag{Name: "discover-pattern", Aliases: []string{"pd"}, Usage: "File containing replacement patterns applied to successful guesses"},
 		&cli.BoolFlag{Name: "no-color", Aliases: []string{"nc"}, Value: false, Usage: "Disable color output"},
 		&cli.BoolFlag{Name: "debug", Value: false, Usage: "enable debug output"},
 	}

--- a/cli/options.go
+++ b/cli/options.go
@@ -213,6 +213,7 @@ func GlobalOptions() []cli.Flag {
 		&cli.BoolFlag{Name: "no-progress", Aliases: []string{"np"}, Value: false, Usage: "Don't display progress"},
 		&cli.BoolFlag{Name: "no-error", Aliases: []string{"ne"}, Value: false, Usage: "Don't display errors"},
 		&cli.StringFlag{Name: "pattern", Aliases: []string{"p"}, Usage: "File containing replacement patterns"},
+		&cli.StringFlag{Name: "discover-pattern", Aliases: []string{"pd"}, Usage: "File containing replacement patterns for successful guesses"},
 		&cli.BoolFlag{Name: "no-color", Aliases: []string{"nc"}, Value: false, Usage: "Disable color output"},
 		&cli.BoolFlag{Name: "debug", Value: false, Usage: "enable debug output"},
 	}
@@ -258,6 +259,26 @@ func ParseGlobalOptions(c *cli.Context) (libgobuster.Options, error) {
 		}
 		if err := scanner.Err(); err != nil {
 			return opts, fmt.Errorf("could not read pattern file %q: %w", opts.PatternFile, err)
+		}
+	}
+
+	opts.DiscoverPatternFile = c.String("discover-pattern")
+	if opts.DiscoverPatternFile != "" {
+		if _, err := os.Stat(opts.PatternFile); os.IsNotExist(err) {
+			return opts, fmt.Errorf("discover pattern file %q does not exist: %w", opts.DiscoverPatternFile, err)
+		}
+		discoverPatternFile, err := os.Open(opts.DiscoverPatternFile)
+		if err != nil {
+			return opts, fmt.Errorf("could not open discover pattern file %q: %w", opts.DiscoverPatternFile, err)
+		}
+		defer discoverPatternFile.Close()
+
+		scanner := bufio.NewScanner(discoverPatternFile)
+		for scanner.Scan() {
+			opts.DiscoverPatterns = append(opts.DiscoverPatterns, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			return opts, fmt.Errorf("could not read discover pattern file %q: %w", opts.DiscoverPatternFile, err)
 		}
 	}
 

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -172,8 +172,17 @@ func getBackupFilenames(word string) []string {
 	return ret
 }
 
+func (d *GobusterDir) AdditionalWordsLen() int {
+	n := len(d.options.ExtensionsParsed.Set)
+	if d.options.DiscoverBackup {
+		n += (n + 1) * (len(backupExtensions) + len(backupDotExtensions))
+	}
+
+	return n
+}
+
 func (d *GobusterDir) AdditionalWords(word string) []string {
-	var words []string
+	words := make([]string, 0, d.AdditionalWordsLen())
 	// build list of urls to check
 	//   1: No extension
 	//   2: With extension

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -157,28 +157,27 @@ func (d *GobusterDir) PreRun(ctx context.Context, _ *libgobuster.Progress) error
 	return nil
 }
 
-func getBackupFilenames(word string) []string {
-	ret := make([]string, len(backupExtensions)+len(backupDotExtensions))
-	i := 0
-	for _, b := range backupExtensions {
-		ret[i] = fmt.Sprintf("%s%s", word, b)
-		i++
-	}
-	for _, b := range backupDotExtensions {
-		ret[i] = fmt.Sprintf(".%s%s", word, b)
-		i++
+func (d *GobusterDir) AdditionalSuccessWords(word string) []string {
+	if d.options.DiscoverBackup {
+		ret := make([]string, len(backupExtensions)+len(backupDotExtensions))
+		i := 0
+		for _, b := range backupExtensions {
+			ret[i] = fmt.Sprintf("%s%s", word, b)
+			i++
+		}
+		for _, b := range backupDotExtensions {
+			ret[i] = fmt.Sprintf(".%s%s", word, b)
+			i++
+		}
+
+		return ret
 	}
 
-	return ret
+	return []string{}
 }
 
 func (d *GobusterDir) AdditionalWordsLen() int {
-	n := len(d.options.ExtensionsParsed.Set)
-	if d.options.DiscoverBackup {
-		n += (n + 1) * (len(backupExtensions) + len(backupDotExtensions))
-	}
-
-	return n
+	return len(d.options.ExtensionsParsed.Set)
 }
 
 func (d *GobusterDir) AdditionalWords(word string) []string {
@@ -186,22 +185,15 @@ func (d *GobusterDir) AdditionalWords(word string) []string {
 	// build list of urls to check
 	//   1: No extension
 	//   2: With extension
-	//   3: backupextension
-	if d.options.DiscoverBackup {
-		words = append(words, getBackupFilenames(word)...)
-	}
 	for ext := range d.options.ExtensionsParsed.Set {
 		filename := fmt.Sprintf("%s.%s", word, ext)
 		words = append(words, filename)
-		if d.options.DiscoverBackup {
-			words = append(words, getBackupFilenames(filename)...)
-		}
 	}
 	return words
 }
 
 // ProcessWord is the process implementation of gobusterdir
-func (d *GobusterDir) ProcessWord(ctx context.Context, word string, progress *libgobuster.Progress) error {
+func (d *GobusterDir) ProcessWord(ctx context.Context, word string, progress *libgobuster.Progress) (libgobuster.Result, error) {
 	suffix := ""
 	if d.options.UseSlash {
 		suffix = "/"
@@ -252,13 +244,13 @@ func (d *GobusterDir) ProcessWord(ctx context.Context, word string, progress *li
 				continue
 			} else {
 				if errors.Is(err, io.EOF) {
-					return libgobuster.ErrorEOF
+					return nil, libgobuster.ErrorEOF
 				} else if os.IsTimeout(err) {
-					return libgobuster.ErrorTimeout
+					return nil, libgobuster.ErrorTimeout
 				} else if errors.Is(err, syscall.ECONNREFUSED) {
-					return libgobuster.ErrorConnectionRefused
+					return nil, libgobuster.ErrorConnectionRefused
 				}
-				return err
+				return nil, err
 			}
 		}
 		break
@@ -276,7 +268,7 @@ func (d *GobusterDir) ProcessWord(ctx context.Context, word string, progress *li
 				resultStatus = true
 			}
 		} else {
-			return fmt.Errorf("StatusCodes and StatusCodesBlacklist are both not set which should not happen")
+			return nil, fmt.Errorf("StatusCodes and StatusCodesBlacklist are both not set which should not happen")
 		}
 
 		if resultStatus && !d.options.ExcludeLengthParsed.Contains(int(size)) {
@@ -298,11 +290,11 @@ func (d *GobusterDir) ProcessWord(ctx context.Context, word string, progress *li
 			if !d.options.HideLength {
 				r.Size = size
 			}
-			progress.ResultChan <- r
+			return r, nil
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 // GetConfigString returns the string representation of the current config

--- a/gobusterdir/gobusterdir_test.go
+++ b/gobusterdir/gobusterdir_test.go
@@ -1,0 +1,38 @@
+package gobusterdir
+
+import (
+	"testing"
+
+	"github.com/OJ/gobuster/v3/libgobuster"
+)
+
+func TestAdditionalWordsLen(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		testName   string
+		backups    bool
+		extensions map[string]bool
+	}{
+		{"Backups no extensions", true, map[string]bool{}},
+		{"No backups no extensions", false, map[string]bool{}},
+		{"Backups and extensions", true, map[string]bool{"htm": true, "html": true, "php": true}},
+		{"No Backups and some extensions", false, map[string]bool{"htm": true, "html": true, "php": true}},
+	}
+
+	globalOpts := libgobuster.Options{}
+	for _, x := range tt {
+		opts := OptionsDir{}
+		opts.DiscoverBackup = x.backups
+		opts.ExtensionsParsed.Set = x.extensions
+
+		d, _ := New(&globalOpts, &opts, nil)
+
+		calculatedLen := d.AdditionalWordsLen()
+		wordsLen := len(d.AdditionalWords("dummy"))
+
+		if calculatedLen != wordsLen {
+			t.Fatalf("Mismatched additional words length: %d got %d generated words %v", calculatedLen, wordsLen, d.AdditionalWords("dummy"))
+		}
+	}
+}

--- a/gobusterdir/gobusterdir_test.go
+++ b/gobusterdir/gobusterdir_test.go
@@ -11,19 +11,15 @@ func TestAdditionalWordsLen(t *testing.T) {
 
 	tt := []struct {
 		testName   string
-		backups    bool
 		extensions map[string]bool
 	}{
-		{"Backups no extensions", true, map[string]bool{}},
-		{"No backups no extensions", false, map[string]bool{}},
-		{"Backups and extensions", true, map[string]bool{"htm": true, "html": true, "php": true}},
-		{"No Backups and some extensions", false, map[string]bool{"htm": true, "html": true, "php": true}},
+		{"No extensions", map[string]bool{}},
+		{"Some extensions", map[string]bool{"htm": true, "html": true, "php": true}},
 	}
 
 	globalOpts := libgobuster.Options{}
 	for _, x := range tt {
 		opts := OptionsDir{}
-		opts.DiscoverBackup = x.backups
 		opts.ExtensionsParsed.Set = x.extensions
 
 		d, _ := New(&globalOpts, &opts, nil)

--- a/gobusterdns/gobusterdns.go
+++ b/gobusterdns/gobusterdns.go
@@ -159,6 +159,10 @@ func (d *GobusterDNS) ProcessWord(ctx context.Context, word string, progress *li
 	return nil
 }
 
+func (d *GobusterDNS) AdditionalWordsLen() int {
+	return 0
+}
+
 func (d *GobusterDNS) AdditionalWords(_ string) []string {
 	return []string{}
 }

--- a/gobusterdns/gobusterdns.go
+++ b/gobusterdns/gobusterdns.go
@@ -109,7 +109,7 @@ func (d *GobusterDNS) PreRun(ctx context.Context, progress *libgobuster.Progress
 }
 
 // ProcessWord is the process implementation of gobusterdns
-func (d *GobusterDNS) ProcessWord(ctx context.Context, word string, progress *libgobuster.Progress) error {
+func (d *GobusterDNS) ProcessWord(ctx context.Context, word string, progress *libgobuster.Progress) (libgobuster.Result, error) {
 	subdomain := fmt.Sprintf("%s.%s", word, d.options.Domain)
 	if !d.options.NoFQDN && !strings.HasSuffix(subdomain, ".") {
 		// add a . to indicate this is the full domain, and we do not want to traverse the search domains on the system
@@ -129,9 +129,9 @@ func (d *GobusterDNS) ProcessWord(ctx context.Context, word string, progress *li
 		var wErr *net.DNSError
 		if errors.As(err, &wErr) && wErr.IsNotFound {
 			// host not found is the expected error here
-			return nil
+			return nil, nil
 		}
-		return err
+		return nil, err
 	}
 
 	if !d.isWildcard || !d.wildcardIps.ContainsAny(ips) {
@@ -154,9 +154,9 @@ func (d *GobusterDNS) ProcessWord(ctx context.Context, word string, progress *li
 				}
 			}
 		}
-		progress.ResultChan <- result
+		return result, nil
 	}
-	return nil
+	return nil, nil
 }
 
 func (d *GobusterDNS) AdditionalWordsLen() int {
@@ -164,6 +164,10 @@ func (d *GobusterDNS) AdditionalWordsLen() int {
 }
 
 func (d *GobusterDNS) AdditionalWords(_ string) []string {
+	return []string{}
+}
+
+func (d *GobusterDNS) AdditionalSuccessWords(_ string) []string {
 	return []string{}
 }
 

--- a/gobusterfuzz/gobusterfuzz.go
+++ b/gobusterfuzz/gobusterfuzz.go
@@ -194,6 +194,10 @@ func (d *GobusterFuzz) ProcessWord(ctx context.Context, word string, progress *l
 	return nil
 }
 
+func (d *GobusterFuzz) AdditionalWordsLen() int {
+	return 0
+}
+
 func (d *GobusterFuzz) AdditionalWords(_ string) []string {
 	return []string{}
 }

--- a/gobustergcs/gobustersgcs.go
+++ b/gobustergcs/gobustersgcs.go
@@ -197,6 +197,10 @@ func (s *GobusterGCS) ProcessWord(ctx context.Context, word string, progress *li
 	return nil
 }
 
+func (s *GobusterGCS) AdditionalWordsLen() int {
+	return 0
+}
+
 func (s *GobusterGCS) AdditionalWords(_ string) []string {
 	return []string{}
 }

--- a/gobusters3/gobusters3.go
+++ b/gobusters3/gobusters3.go
@@ -189,6 +189,10 @@ func (s *GobusterS3) ProcessWord(ctx context.Context, word string, progress *lib
 	return nil
 }
 
+func (s *GobusterS3) AdditionalWordsLen() int {
+	return 0
+}
+
 func (s *GobusterS3) AdditionalWords(_ string) []string {
 	return []string{}
 }

--- a/gobustertftp/gobustertftp.go
+++ b/gobustertftp/gobustertftp.go
@@ -51,7 +51,7 @@ func (d *GobusterTFTP) PreRun(_ context.Context, _ *libgobuster.Progress) error 
 }
 
 // ProcessWord is the process implementation of gobustertftp
-func (d *GobusterTFTP) ProcessWord(_ context.Context, word string, progress *libgobuster.Progress) error {
+func (d *GobusterTFTP) ProcessWord(_ context.Context, word string, progress *libgobuster.Progress) (libgobuster.Result, error) {
 	// add some debug output
 	if d.globalopts.Debug {
 		progress.MessageChan <- libgobuster.Message{
@@ -62,13 +62,13 @@ func (d *GobusterTFTP) ProcessWord(_ context.Context, word string, progress *lib
 
 	c, err := tftp.NewClient(d.options.Server)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	c.SetTimeout(d.options.Timeout)
 	wt, err := c.Receive(word, "octet")
 	if err != nil {
 		// file not found
-		return nil
+		return nil, nil
 	}
 	result := Result{
 		Filename: word,
@@ -76,8 +76,7 @@ func (d *GobusterTFTP) ProcessWord(_ context.Context, word string, progress *lib
 	if n, ok := wt.(tftp.IncomingTransfer).Size(); ok {
 		result.Size = n
 	}
-	progress.ResultChan <- result
-	return nil
+	return result, nil
 }
 
 func (d *GobusterTFTP) AdditionalWordsLen() int {
@@ -85,6 +84,10 @@ func (d *GobusterTFTP) AdditionalWordsLen() int {
 }
 
 func (d *GobusterTFTP) AdditionalWords(_ string) []string {
+	return []string{}
+}
+
+func (d *GobusterTFTP) AdditionalSuccessWords(_ string) []string {
 	return []string{}
 }
 

--- a/gobustertftp/gobustertftp.go
+++ b/gobustertftp/gobustertftp.go
@@ -80,6 +80,10 @@ func (d *GobusterTFTP) ProcessWord(_ context.Context, word string, progress *lib
 	return nil
 }
 
+func (d *GobusterTFTP) AdditionalWordsLen() int {
+	return 0
+}
+
 func (d *GobusterTFTP) AdditionalWords(_ string) []string {
 	return []string{}
 }

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -206,6 +206,10 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 	return nil
 }
 
+func (v *GobusterVhost) AdditionalWordsLen() int {
+	return 0
+}
+
 func (v *GobusterVhost) AdditionalWords(_ string) []string {
 	return []string{}
 }

--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -128,7 +128,7 @@ func (v *GobusterVhost) PreRun(ctx context.Context, _ *libgobuster.Progress) err
 }
 
 // ProcessWord is the process implementation of gobusterdir
-func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *libgobuster.Progress) error {
+func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *libgobuster.Progress) (libgobuster.Result, error) {
 	var subdomain string
 	if v.options.AppendDomain {
 		subdomain = fmt.Sprintf("%s.%s", word, v.domain)
@@ -180,13 +180,13 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 				continue
 			} else {
 				if errors.Is(err, io.EOF) {
-					return libgobuster.ErrorEOF
+					return nil, libgobuster.ErrorEOF
 				} else if os.IsTimeout(err) {
-					return libgobuster.ErrorTimeout
+					return nil, libgobuster.ErrorTimeout
 				} else if errors.Is(err, syscall.ECONNREFUSED) {
-					return libgobuster.ErrorConnectionRefused
+					return nil, libgobuster.ErrorConnectionRefused
 				}
-				return err
+				return nil, err
 			}
 		}
 		break
@@ -196,14 +196,15 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 	// or verbose mode is enabled
 	found := body != nil && !bytes.Equal(body, v.normalBody) && !bytes.Equal(body, v.abnormalBody)
 	if found && !v.options.ExcludeLengthParsed.Contains(int(size)) && !v.options.ExcludeStatusParsed.Contains(statusCode) {
-		progress.ResultChan <- Result{
+		r := Result{
 			Vhost:      subdomain,
 			StatusCode: statusCode,
 			Size:       size,
 			Header:     header,
 		}
+		return r, nil
 	}
-	return nil
+	return nil, nil
 }
 
 func (v *GobusterVhost) AdditionalWordsLen() int {
@@ -211,6 +212,10 @@ func (v *GobusterVhost) AdditionalWordsLen() int {
 }
 
 func (v *GobusterVhost) AdditionalWords(_ string) []string {
+	return []string{}
+}
+
+func (v *GobusterVhost) AdditionalSuccessWords(_ string) []string {
 	return []string{}
 }
 

--- a/libgobuster/interfaces.go
+++ b/libgobuster/interfaces.go
@@ -6,9 +6,10 @@ import "context"
 type GobusterPlugin interface {
 	Name() string
 	PreRun(context.Context, *Progress) error
-	ProcessWord(context.Context, string, *Progress) error
+	ProcessWord(context.Context, string, *Progress) (Result, error)
 	AdditionalWords(string) []string
 	AdditionalWordsLen() int
+	AdditionalSuccessWords(string) []string
 	GetConfigString() (string, error)
 }
 

--- a/libgobuster/interfaces.go
+++ b/libgobuster/interfaces.go
@@ -8,6 +8,7 @@ type GobusterPlugin interface {
 	PreRun(context.Context, *Progress) error
 	ProcessWord(context.Context, string, *Progress) error
 	AdditionalWords(string) []string
+	AdditionalWordsLen() int
 	GetConfigString() (string, error)
 }
 

--- a/libgobuster/libgobuster.go
+++ b/libgobuster/libgobuster.go
@@ -44,6 +44,12 @@ func NewGobuster(opts *Options, plugin GobusterPlugin, logger *Logger) (*Gobuste
 func (g *Gobuster) worker(ctx context.Context, wordChan <-chan string, moreWordsChan chan<- string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for {
+		// Prioritize stopping when the context is done
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		select {
 		case <-ctx.Done():
 			return
@@ -84,6 +90,12 @@ func (g *Gobuster) worker(ctx context.Context, wordChan <-chan string, moreWords
 
 func feed(ctx context.Context, wordChan chan<- string, words []string) {
 	for _, w := range words {
+		// Prioritize stopping when the context is done
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		select {
 		// need to check here too otherwise wordChan will block
 		case <-ctx.Done():
@@ -103,6 +115,13 @@ func (g *Gobuster) feedScanner(ctx context.Context, wordChan chan<- string, scan
 	defer wg.Done()
 
 	for scanner.Scan() {
+		// Prioritize stopping when the context is done
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		word := scanner.Text()
 		// add the original word
 		select {
@@ -211,6 +230,13 @@ func (g *Gobuster) Run(ctx context.Context) error {
 
 ListenForMore:
 	for {
+		// Prioritize stopping when the context is done
+		select {
+		case <-ctx.Done():
+			break ListenForMore
+		default:
+		}
+
 		select {
 		case <-ctx.Done():
 			break ListenForMore

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -6,15 +6,17 @@ import (
 
 // Options holds all options that can be passed to libgobuster
 type Options struct {
-	Threads        int
-	Debug          bool
-	Wordlist       string
-	WordlistOffset int
-	PatternFile    string
-	Patterns       []string
-	OutputFilename string
-	NoProgress     bool
-	NoError        bool
-	Quiet          bool
-	Delay          time.Duration
+	Threads             int
+	Debug               bool
+	Wordlist            string
+	WordlistOffset      int
+	PatternFile         string
+	DiscoverPatternFile string
+	Patterns            []string
+	DiscoverPatterns    []string
+	OutputFilename      string
+	NoProgress          bool
+	NoError             bool
+	Quiet               bool
+	Delay               time.Duration
 }

--- a/libgobuster/progress.go
+++ b/libgobuster/progress.go
@@ -62,7 +62,7 @@ func (p *Progress) incrementRequests() {
 }
 
 func (p *Progress) IncrementTotalRequests(by int) {
-	p.requestsCountMutex.Lock()
-	defer p.requestsCountMutex.Unlock()
+	p.requestsExpectedMutex.Lock()
+	defer p.requestsExpectedMutex.Unlock()
 	p.requestsExpected += by
 }


### PR DESCRIPTION
Hi all, this resolves the issues where patterns were not counted towards possible attempts, file extension searching was not applied to patterns in `GobusterDir`, and backups were being brute-forced for the entire wordlist. These all had pretty tangled fixes so I lumped them into this PR.

```
$  ./gobuster dir -p patterns.txt -w testwords.txt -x .php,.html -db -u https://testing.test
===============================================================
Gobuster v3.7
by OJ Reeves (@TheColonial) & Christian Mehlmauer (@firefart)
===============================================================
[+] Url:                     https://testing.test
[+] Method:                  GET
[+] Threads:                 10
[+] Wordlist:                testwords.txt
[+] Patterns:                patterns.txt (2 entries)
[+] Negative Status codes:   404
[+] User Agent:              gobuster/3.7
[+] Extensions:              php,html
[+] Timeout:                 10s
===============================================================
Starting gobuster in directory enumeration mode
===============================================================
/index.html           (Status: 200) [Size: 179]
/index.html.bak       (Status: 200) [Size: 179]
Progress: 33 / 33 (100.00%)
===============================================================
Finished
===============================================================
$ wc -l testwords.txt patterns.txt 
 3 testwords.txt
 3 patterns.txt
 5 total
```

Note the 33 total attempts for:

```
3 words * 3 patterns * (2 file extensions + no file extension) = 27 original attempts
plus 6 backup styles for the original find of "index.html"
```

~Since it's in this wheelhouse, I'm open to also changing the pattern generation and wordlist behavior to either have a flag for the exclusion of the bare words from the wordlist that's either on or off by default or even make patterns always supersede the wordlist and make users add a plain `{GOBUSTER}` pattern if they want the original word in addition to the patterns. I'm not sure which would be the most useful, though.~

Looking through the old issues, it seems that (1) filtering the whole wordlist through the patterns and (2) applying the discovery patterns exactly once would be the most consistent behavior.

Fixes #298, #405, #480, #533, #319, #364


There are still a couple of things to do before this is ready, but I wanted to get this open for some eyes:
- [x]  I need to track successes from success pattern generation to keep it from infinitely generating requests against malicious services/with misconfiguration, possibly with a configurable chain generation limit
- [x] I want to add a global flag for post-find pattern expansion, so that if the user desired everything could be checked with patterns after a successful find