### PR TITLE
feat: add the ability to use regex to inspect the response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,10 @@ gobuster dir -u https://example.com -w wordlist.txt -s 200,301,302
 
 # Filter using a regex against the response body
 # This can be handy for websites that return status code 200 for everything, but the html contains an error message
-# NOTE: we need to exclude status codes `200` for this to work
-gobuster dir -u https://example.com -w wordlist.txt -b 200 -re "error\shello"
+gobuster dir -u https://example.com -w wordlist.txt -re "error\shello"
 
 # Filter using a regex but inverted against the response body
-gobuster dir -u https://example.com -w wordlist.txt -b 200 -rei "(?i)\berror\b"
+gobuster dir -u https://example.com -w wordlist.txt -rei "(?i)\berror\b"
 ```
 
 #### 🔍 DNS Mode (`dns`)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ gobuster dir -u https://example.com -w wordlist.txt -s 200,301,302
 # This can be handy for websites that return status code 200 for everything, but the html contains an error message
 # NOTE: we need to exclude status codes `200` for this to work
 gobuster dir -u https://example.com -w wordlist.txt -b 200 -re "error\shello"
+
+# Filter using a regex but inverted against the response body
+gobuster dir -u https://example.com -w wordlist.txt -b 200 -rei "(?i)\berror\b"
 ```
 
 #### 🔍 DNS Mode (`dns`)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ gobuster dir -u https://example.com -w wordlist.txt -l
 
 # Filter by status codes
 gobuster dir -u https://example.com -w wordlist.txt -s 200,301,302
+
+# Filter using a regex against the response body
+# This can be handy for websites that return status code 200 for everything, but the html contains an error message
+# NOTE: we need to exclude status codes `200` for this to work
+gobuster dir -u https://example.com -w wordlist.txt -b 200 -re "error\shello"
 ```
 
 #### 🔍 DNS Mode (`dns`)

--- a/cli/dir/dir.go
+++ b/cli/dir/dir.go
@@ -3,6 +3,7 @@ package dir
 import (
 	"errors"
 	"fmt"
+	"regexp"
 
 	internalcli "github.com/OJ/gobuster/v3/cli"
 	"github.com/OJ/gobuster/v3/gobusterdir"
@@ -36,6 +37,7 @@ func getFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "discover-backup", Aliases: []string{"db"}, Value: false, Usage: "Upon finding a file search for backup files by appending multiple backup extensions"},
 		&cli.StringFlag{Name: "exclude-length", Aliases: []string{"xl"}, Usage: "exclude the following content lengths (completely ignores the status). You can separate multiple lengths by comma and it also supports ranges like 203-206"},
 		&cli.BoolFlag{Name: "force", Value: false, Usage: "Continue even if the prechecks fail. Please only use this if you know what you are doing, it can lead to unexpected results."},
+		&cli.StringFlag{Name: "regex", Aliases: []string{"re"}, Usage: "Use regex to filter the results, by inspecting the content of the response body."},
 	}...)
 	return flags
 }
@@ -100,6 +102,16 @@ func run(c *cli.Context) error {
 		return fmt.Errorf("invalid value for exclude-length: %w", err)
 	}
 	pluginOpts.ExcludeLengthParsed = ret4
+
+	pluginOpts.Regex = c.String("regex")
+	if c.IsSet("regex") {
+
+		parsedRegex, err := regexp.Compile(pluginOpts.Regex)
+		if err != nil {
+			return fmt.Errorf("invalid value for regex: %w", err)
+		}
+		pluginOpts.RegexParsed = parsedRegex
+	}
 
 	globalOpts, err := internalcli.ParseGlobalOptions(c)
 	if err != nil {

--- a/cli/dir/dir.go
+++ b/cli/dir/dir.go
@@ -38,6 +38,7 @@ func getFlags() []cli.Flag {
 		&cli.StringFlag{Name: "exclude-length", Aliases: []string{"xl"}, Usage: "exclude the following content lengths (completely ignores the status). You can separate multiple lengths by comma and it also supports ranges like 203-206"},
 		&cli.BoolFlag{Name: "force", Value: false, Usage: "Continue even if the prechecks fail. Please only use this if you know what you are doing, it can lead to unexpected results."},
 		&cli.StringFlag{Name: "regex", Aliases: []string{"re"}, Usage: "Use regex to filter the results, by inspecting the content of the response body."},
+		&cli.StringFlag{Name: "regex-invert", Aliases: []string{"rei"}, Usage: "Use regex to filter the results, but inverted, by inspecting the content of the response body."},
 	}...)
 	return flags
 }
@@ -103,9 +104,16 @@ func run(c *cli.Context) error {
 	}
 	pluginOpts.ExcludeLengthParsed = ret4
 
-	pluginOpts.Regex = c.String("regex")
 	if c.IsSet("regex") {
+		pluginOpts.Regex = c.String("regex")
+	}
 
+	if c.IsSet("regex-invert") {
+		pluginOpts.Regex = c.String("regex-invert")
+		pluginOpts.RegexInvert = true
+	}
+
+	if pluginOpts.Regex != "" {
 		parsedRegex, err := regexp.Compile(pluginOpts.Regex)
 		if err != nil {
 			return fmt.Errorf("invalid value for regex: %w", err)

--- a/gobusterdir/gobusterdir.go
+++ b/gobusterdir/gobusterdir.go
@@ -291,8 +291,12 @@ func (d *GobusterDir) ProcessWord(ctx context.Context, word string, progress *li
 		resultStatus := false
 
 		// check body with the regex
-		if d.options.RegexParsed != nil && body != nil && d.options.RegexParsed.Match(body) {
-			resultStatus = true
+		if d.options.RegexParsed != nil && body != nil {
+			if d.options.RegexInvert {
+				resultStatus = !d.options.RegexParsed.Match(body)
+			} else {
+				resultStatus = d.options.RegexParsed.Match(body)
+			}
 		}
 
 		switch {

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -1,6 +1,8 @@
 package gobusterdir
 
 import (
+	"regexp"
+
 	"github.com/OJ/gobuster/v3/libgobuster"
 )
 
@@ -22,6 +24,8 @@ type OptionsDir struct {
 	ExcludeLength              string
 	ExcludeLengthParsed        libgobuster.Set[int]
 	Force                      bool
+	Regex 					   string
+	RegexParsed                *regexp.Regexp
 }
 
 // NewOptions returns a new initialized OptionsDir

--- a/gobusterdir/options.go
+++ b/gobusterdir/options.go
@@ -26,6 +26,7 @@ type OptionsDir struct {
 	Force                      bool
 	Regex 					   string
 	RegexParsed                *regexp.Regexp
+	RegexInvert                bool
 }
 
 // NewOptions returns a new initialized OptionsDir


### PR DESCRIPTION
This is a feature I have been wanting and using in several of my own projects.

This allows you to use a regex to filter pages based on the response body, you can also invert the regex, to find pages that don't match.

This covers: https://github.com/OJ/gobuster/issues/288 and https://github.com/OJ/gobuster/issues/5