### PR TITLE
Add --json/-j flag to output results in JSON format

### DIFF
--- a/cli/gobuster.go
+++ b/cli/gobuster.go
@@ -25,33 +25,79 @@ func resultWorker(g *libgobuster.Gobuster, filename string, wg *sync.WaitGroup) 
 
 	var f *os.File
 	var err error
+	var firstResult = true
+
 	if filename != "" {
 		f, err = os.Create(filename)
 		if err != nil {
 			g.Logger.Fatalf("error on creating output file: %v", err)
 		}
 		defer f.Close()
+
+		// Write opening bracket for JSON array if outputting JSON to file
+		if g.Opts.OutputAsJSON {
+			if _, err := f.WriteString("[\n"); err != nil {
+				g.Logger.Fatalf("error writing to output file: %v", err)
+			}
+		}
 	}
 
 	for r := range g.Progress.ResultChan {
-		s, err := r.ResultToString()
-		if err != nil {
-			g.Logger.Fatal(err)
-		}
-		if s != "" {
-			s = strings.TrimSpace(s)
-			if g.Opts.NoProgress || g.Opts.Quiet {
-				_, _ = fmt.Printf("%s\n", s) // nolint forbidigo
-			} else {
-				// only print the clear line when progress output is enabled
-				_, _ = fmt.Printf("%s%s\n", TerminalClearLine, s) // nolint forbidigo
+		var output string
+		
+		if g.Opts.OutputAsJSON {
+			// JSON output
+			jsonBytes, err := r.ResultToJSON()
+			if err != nil {
+				g.Logger.Fatal(err)
 			}
-			if f != nil {
-				err = writeToFile(f, s)
-				if err != nil {
-					g.Logger.Fatalf("error on writing output file: %v", err)
+			output = string(jsonBytes)
+		} else {
+			// String output
+			s, err := r.ResultToString()
+			if err != nil {
+				g.Logger.Fatal(err)
+			}
+			output = strings.TrimSpace(s)
+		}
+		
+		if output != "" {
+			// Don't print to console if we're outputting JSON to a file
+			if !g.Opts.OutputAsJSON {
+				if g.Opts.NoProgress || g.Opts.Quiet {
+					_, _ = fmt.Printf("%s\n", output) // nolint forbidigo
+				} else {
+					// only print the clear line when progress output is enabled
+					_, _ = fmt.Printf("%s%s\n", TerminalClearLine, output) // nolint forbidigo
 				}
 			}
+			if f != nil {
+				// For JSON output to file, add commas between objects and indent
+				if g.Opts.OutputAsJSON {
+					if !firstResult {
+						if _, err := f.WriteString(",\n"); err != nil {
+							g.Logger.Fatalf("error writing to output file: %v", err)
+						}
+					}
+					firstResult = false
+					// Indent the JSON object
+					if _, err := f.WriteString("  " + output); err != nil {
+						g.Logger.Fatalf("error writing to output file: %v", err)
+					}
+				} else {
+					err = writeToFile(f, output)
+					if err != nil {
+						g.Logger.Fatalf("error on writing output file: %v", err)
+					}
+				}
+			}
+		}
+	}
+
+	// Write closing bracket for JSON array if outputting JSON to file
+	if f != nil && g.Opts.OutputAsJSON {
+		if _, err := f.WriteString("\n]\n"); err != nil {
+			g.Logger.Fatalf("error writing to output file: %v", err)
 		}
 	}
 }

--- a/cli/options.go
+++ b/cli/options.go
@@ -225,6 +225,7 @@ func GlobalOptions() []cli.Flag {
 		&cli.StringFlag{Name: "pattern", Aliases: []string{"p"}, Usage: "File containing replacement patterns"},
 		&cli.StringFlag{Name: "discover-pattern", Aliases: []string{"pd"}, Usage: "File containing replacement patterns applied to successful guesses"},
 		&cli.BoolFlag{Name: "no-color", Aliases: []string{"nc"}, Value: false, Usage: "Disable color output"},
+		&cli.BoolFlag{Name: "json", Aliases: []string{"j"}, Value: false, Usage: "Output results in JSON format (requires --output)"},
 		&cli.BoolFlag{Name: "debug", Value: false, Usage: "enable debug output"},
 	}
 }
@@ -249,6 +250,13 @@ func ParseGlobalOptions(c *cli.Context) (libgobuster.Options, error) {
 	}
 
 	opts.OutputFilename = c.String("output")
+	opts.OutputAsJSON = c.Bool("json")
+	
+	// JSON output requires a file
+	if opts.OutputAsJSON && opts.OutputFilename == "" {
+		return opts, errors.New("JSON output (--json) requires an output file (--output)")
+	}
+	
 	opts.Quiet = c.Bool("quiet")
 	opts.NoProgress = c.Bool("no-progress")
 	opts.NoError = c.Bool("no-error")

--- a/gobusterdir/result.go
+++ b/gobusterdir/result.go
@@ -2,8 +2,10 @@ package gobusterdir
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/fatih/color"
 )
@@ -66,4 +68,25 @@ func (r Result) ResultToString() (string, error) {
 	s := buf.String()
 
 	return s, nil
+}
+
+// ResultToJSON converts the Result to JSON
+func (r Result) ResultToJSON() ([]byte, error) {
+	type JSONResult struct {
+		Path       string      `json:"path"`
+		StatusCode int         `json:"status_code"`
+		Size       int64       `json:"size"`
+		Location   string      `json:"location,omitempty"`
+		Header     http.Header `json:"header,omitempty"`
+	}
+
+	jr := JSONResult{
+		Path:       strings.TrimSpace(r.Path),
+		StatusCode: r.StatusCode,
+		Size:       r.Size,
+		Location:   r.Header.Get("Location"),
+		Header:     r.Header,
+	}
+
+	return json.Marshal(jr)
 }

--- a/gobusterdns/result.go
+++ b/gobusterdns/result.go
@@ -2,6 +2,7 @@ package gobusterdns
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/netip"
 	"strings"
@@ -44,4 +45,27 @@ func (r Result) ResultToString() (string, error) {
 
 	s := buf.String()
 	return s, nil
+}
+
+// ResultToJSON converts the Result to JSON
+func (r Result) ResultToJSON() ([]byte, error) {
+	type JSONResult struct {
+		Subdomain string   `json:"subdomain"`
+		IPs       []string `json:"ips,omitempty"`
+		CNAME     string   `json:"cname,omitempty"`
+	}
+
+	jr := JSONResult{
+		Subdomain: r.Subdomain,
+		CNAME:     r.CNAME,
+	}
+
+	if len(r.IPs) > 0 {
+		jr.IPs = make([]string, len(r.IPs))
+		for i := range r.IPs {
+			jr.IPs[i] = r.IPs[i].String()
+		}
+	}
+
+	return json.Marshal(jr)
 }

--- a/gobusterfuzz/result.go
+++ b/gobusterfuzz/result.go
@@ -2,6 +2,7 @@ package gobusterfuzz
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -38,4 +39,27 @@ func (r Result) ResultToString() (string, error) {
 	}
 	s := buf.String()
 	return s, nil
+}
+
+// ResultToJSON converts the Result to JSON
+func (r Result) ResultToJSON() ([]byte, error) {
+	type JSONResult struct {
+		Word       string      `json:"word"`
+		Path       string      `json:"path"`
+		StatusCode int         `json:"status_code"`
+		Size       int64       `json:"size"`
+		Location   string      `json:"location,omitempty"`
+		Header     http.Header `json:"header,omitempty"`
+	}
+
+	jr := JSONResult{
+		Word:       r.Word,
+		Path:       r.Path,
+		StatusCode: r.StatusCode,
+		Size:       r.Size,
+		Location:   r.Header.Get("Location"),
+		Header:     r.Header,
+	}
+
+	return json.Marshal(jr)
 }

--- a/gobustergcs/result.go
+++ b/gobustergcs/result.go
@@ -2,6 +2,8 @@ package gobustergcs
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 
 	"github.com/fatih/color"
 )
@@ -30,4 +32,23 @@ func (r Result) ResultToString() (string, error) {
 
 	str := buf.String()
 	return str, nil
+}
+
+// ResultToJSON converts the Result to JSON
+func (r Result) ResultToJSON() ([]byte, error) {
+	type JSONResult struct {
+		Found      bool   `json:"found"`
+		BucketName string `json:"bucket_name"`
+		Status     string `json:"status,omitempty"`
+		URL        string `json:"url"`
+	}
+
+	jr := JSONResult{
+		Found:      r.Found,
+		BucketName: r.BucketName,
+		Status:     r.Status,
+		URL:        fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o", r.BucketName),
+	}
+
+	return json.Marshal(jr)
 }

--- a/gobusters3/result.go
+++ b/gobusters3/result.go
@@ -2,6 +2,8 @@ package gobusters3
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 
 	"github.com/fatih/color"
 )
@@ -30,4 +32,23 @@ func (r Result) ResultToString() (string, error) {
 
 	str := buf.String()
 	return str, nil
+}
+
+// ResultToJSON converts the Result to JSON
+func (r Result) ResultToJSON() ([]byte, error) {
+	type JSONResult struct {
+		Found      bool   `json:"found"`
+		BucketName string `json:"bucket_name"`
+		Status     string `json:"status,omitempty"`
+		URL        string `json:"url"`
+	}
+
+	jr := JSONResult{
+		Found:      r.Found,
+		BucketName: r.BucketName,
+		Status:     r.Status,
+		URL:        fmt.Sprintf("http://%s.s3.amazonaws.com/", r.BucketName),
+	}
+
+	return json.Marshal(jr)
 }

--- a/gobustertftp/result.go
+++ b/gobustertftp/result.go
@@ -2,6 +2,7 @@ package gobustertftp
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/fatih/color"
@@ -33,4 +34,21 @@ func (r Result) ResultToString() (string, error) {
 
 	s := buf.String()
 	return s, nil
+}
+
+// ResultToJSON converts the Result to JSON
+func (r Result) ResultToJSON() ([]byte, error) {
+	type JSONResult struct {
+		Filename     string `json:"filename"`
+		Size         int64  `json:"size"`
+		ErrorMessage string `json:"error_message,omitempty"`
+	}
+
+	jr := JSONResult{
+		Filename:     r.Filename,
+		Size:         r.Size,
+		ErrorMessage: r.ErrorMessage,
+	}
+
+	return json.Marshal(jr)
 }

--- a/gobustervhost/result.go
+++ b/gobustervhost/result.go
@@ -1,6 +1,7 @@
 package gobustervhost
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -47,4 +48,25 @@ func (r Result) ResultToString() (string, error) {
 	}
 
 	return fmt.Sprintf("%s %s [Size: %d]%s\n", r.Vhost, statusCode, r.Size, locationString), nil
+}
+
+// ResultToJSON converts the Result to JSON
+func (r Result) ResultToJSON() ([]byte, error) {
+	type JSONResult struct {
+		Vhost      string      `json:"vhost"`
+		StatusCode int         `json:"status_code"`
+		Size       int64       `json:"size"`
+		Location   string      `json:"location,omitempty"`
+		Header     http.Header `json:"header,omitempty"`
+	}
+
+	jr := JSONResult{
+		Vhost:      r.Vhost,
+		StatusCode: r.StatusCode,
+		Size:       r.Size,
+		Location:   r.Header.Get("Location"),
+		Header:     r.Header,
+	}
+
+	return json.Marshal(jr)
 }

--- a/libgobuster/interfaces.go
+++ b/libgobuster/interfaces.go
@@ -16,4 +16,5 @@ type GobusterPlugin interface {
 // Result is an interface for the Result object
 type Result interface {
 	ResultToString() (string, error)
+	ResultToJSON() ([]byte, error)
 }

--- a/libgobuster/options.go
+++ b/libgobuster/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	Patterns            []string
 	DiscoverPatterns    []string
 	OutputFilename      string
+	OutputAsJSON        bool
 	NoProgress          bool
 	NoError             bool
 	Quiet               bool


### PR DESCRIPTION
- JSON output requires --output flag and writes to file only
- Implement ResultToJSON() method for all result types:
  * gobusterdir: path, status_code, size, location, headers
  * gobusterdns: subdomain, IPs, CNAME
  * gobusterfuzz: word, path, status_code, size, location, headers
  * gobustervhost: vhost, status_code, size, location, headers
  * gobusters3: found, bucket_name, status, URL
  * gobustergcs: found, bucket_name, status, URL
  * gobustertftp: filename, size, error_message
- File output formats results as valid JSON array with indentation
- Results only written to file, not printed to console when using JSON