### PR TITLE
Replace string concatenation in a loop by strings.Builder

### DIFF
--- a/gobustergcs/gobustersgcs.go
+++ b/gobustergcs/gobustersgcs.go
@@ -196,7 +196,7 @@ func (s *GobusterGCS) ProcessWord(ctx context.Context, word string, progress *li
 				if i > 0 {
 					extraStrBuilder.WriteString(", ")
 				}
-				_, err := fmt.Fprintf(&extraStrBuilder, "%s (%sb), ", x.Name, x.Size)
+				_, err := fmt.Fprintf(&extraStrBuilder, "%s (%sb)", x.Name, x.Size)
 				if err != nil {
 					return nil, fmt.Errorf("fmt.Fprintf to strings.Builder failed: %w", err)
 				}


### PR DESCRIPTION
This PR fixes issues mentioned by linter ([perfsprint](https://github.com/catenacyber/perfsprint#:~:text=concat%2Dloop%20(replacing%20string%20concatenation%20in%20a%20loop%20by%20strings.Builder))): [https://github.com/OJ/gobuster/actions/runs/19805194104](https://github.com/OJ/gobuster/actions/runs/19805194104)


In this PR, string concatenation in the loop is replaced by `strings.Builder` in files `gobustergcs/gobustersgcs.go` and `gobusters3/gobusters3.go`.

Note: It is possible to avoid using `fmt.Fprintf` altogether here; however, to minimize the change and save, I have decided to keep it. 