### PR TITLE
Fix --exclude-hostname-length feature

### DIFF
--- a/gobustervhost/gobustervhost.go
+++ b/gobustervhost/gobustervhost.go
@@ -135,7 +135,7 @@ func (v *GobusterVhost) ProcessWord(ctx context.Context, word string, progress *
 		subdomain = word
 	}
 	if v.options.ExcludeHostnameLength {
-		hostnameLength = len(subdomain)
+		hostnameLength = len(word)
 	} else {
 		hostnameLength = 0
 	}


### PR DESCRIPTION
## Issue description
In v3.8.2, the `--exclude-hostname-length` feature stopped working due to an incorrect variable reference.

The hostname length was calculated using `len(subdomain)` instead of `len(word)`, resulting in wrong filtering behavior.

<img width="1418" height="703" alt="gobuster_not_working" src="https://github.com/user-attachments/assets/c19ea2f3-88ab-4fb8-9ba1-d739d0a31171" />

## Root cause
A regression introduced in v3.8.2 caused `hostnameLength` to reference the `subdomain` variable instead of the original `word` value.

## Fix
`hostnameLength` is now correctly assigned using `len(word)`, restoring the expected filtering behavior.
